### PR TITLE
Docs: Lab 1 test plan, reviewer record, and AI use notes

### DIFF
--- a/docs/lab-01/ai_use.md
+++ b/docs/lab-01/ai_use.md
@@ -1,13 +1,30 @@
-# Lab 1 — AI Use and Reflection  (fill this in)
+# Lab 1 — AI Use and Reflection
 
-**LLM/agent used:** <name>
+**LLM/agent used:** Claude Opus 5 — used in two modes: Claude (chat) to turn the labsheet into a
+step-by-step plan (`Lab1_Plan_Beginner.md`), and Claude Code (terminal coding agent) to execute that
+plan: git/GitHub operations, code, migrations, tests, and verification.
 
-## Selected key prompts (6–10)
-| # | Prompt (summarised) | What I did with the result |
-|---|---------------------|----------------------------|
-| 1 |  |  |
-| 2 |  |  |
+## Selected key prompts
+
+| # | Prompt name | Actual prompt text (abridged where marked) | What I did with the result |
+|---|---|---|---|
+| 1 | Plan Lab 1 implementation | "อ่าน Lab1_Labsheet.pdf แล้ววางแผนงานฉบับมือใหม่ ทำเป็น phase/step ให้ครบ บอกด้วยว่าตรงไหนต้องถ่าย screenshot" | Produced the 6-phase / 24-step plan I followed for the whole lab. |
+| 2 | Cross-check the documents | "Cheat Sheet บอกให้แตก branch จาก main แต่ labsheet ใช้ lab1-staging อันไหนถูก" | Agent flagged the conflict and chose `lab1-staging`, because Issue 4 needs the `Category` model merged from Issue 3. |
+| 3 | Kick off the coding agent | "…ทำตาม Lab1_Plan_Beginner.md ข้อบังคับ: ห้าม commit ตรงเข้า main/lab1-staging, PR ทุกใบ base = lab1-staging, สร้าง Issue ครบ 4 ใบก่อนเขียนโค้ด, ห้าม commit .env/node_modules, tech stack ล็อกไว้แล้ว" (abridged) | Set the guardrails for every later step; the agent created the repo scaffold, `lab1-staging`, and the four Issues before any code. |
+| 4 | Create the four Issues | "สร้าง Issue ครบ 4 ใบ ก๊อป acceptance criteria จาก labsheet §7 ใส่ให้ครบ" | Four Issues with the exact acceptance criteria as checklists, auto-added to the board in Backlog. |
+| 5 | Health check endpoint | "แก้ server/src/app.ts แทนที่ TODO(Issue 2) ให้ GET /api/health คืน 200 { status: ok, service: TokTickIT API } แล้วรัน npm test" | `feature/2-health-check`; the provided Supertest test turned green. |
+| 6 | Idempotent seed | "เพิ่ม model Category, migrate, แล้วเขียน seed ด้วย upsert ให้รันซ้ำได้โดยไม่มีข้อมูลซ้ำ แล้วพิสูจน์ด้วยการรัน seed 2 รอบ" | `feature/3-category-seed`; seed run twice → still exactly 4 rows. |
+| 7 | Category list end to end | "เขียน GET /api/categories (select id,name / orderBy id / catch เป็น 500 ข้อความกลางๆ), checkSystem() ฝั่ง client, และ UI loading/success/error พร้อมเทสต์" | `feature/4-category-list`; one Supertest test and three Vitest tests. |
+| 8 | Verify, don't assume | "อันนี้เช็กแล้วใช่ไหมว่าทุกอย่างครบและถูกต้อง" | Agent merged all branches into a throwaway branch, ran both test suites, typechecked, curled both endpoints, and drove the browser for the Online and Offline cases — and reported the gaps it had not done. |
+| 9 | Review the agent's work | "3 จุดต้องแก้: docs ยังว่าง, feature/4 ยังไม่ push, และ /api/health ยังเป็น 501 บน feature/4 — อย่าถ่าย demo จาก feature/4" | I caught that evidence must be captured on `main` after all PRs merge, not on a feature branch. |
+| 10 | Tighten a test to the rubric | "tests.md เขียน UI-02 ว่า loading state changes to category list แต่เทสต์ข้าม assertion loading ไป — เพิ่ม assertion ให้ตรง" | Rewrote UI-02 to hold the mocked promise open, assert `⏳ loading…` and the disabled button, then resolve and assert the list. |
 
 ## Reflection
-Two or three sentences: what made your prompts better, and one place you had to
-correct or reject what the agent produced.
+
+Prompts got better when I stopped asking for outcomes ("make the app work") and started stating the
+constraint and the proof ("PR base must be `lab1-staging`", "prove the seed is idempotent by running
+it twice"), because the agent then produced evidence instead of claims. The most useful habit was
+asking "did you actually verify this?" — the first completion report listed work as done that was
+only written, not run. I also had to reject the agent's plan to capture demo and test screenshots
+from `feature/4-category-list`: `/api/health` is still the 501 stub on that branch, so the app would
+have shown Offline; the evidence has to come from `main` after every PR is merged.

--- a/docs/lab-01/reviewer.md
+++ b/docs/lab-01/reviewer.md
@@ -1,19 +1,31 @@
-# Lab 1 — Peer Review Record  (fill this in)
+# Lab 1 — Peer Review Record
 
-**Author:** <your name> — <student id> — GitHub: @<username>
-**Peer reviewer:** <partner name> — <student id> — GitHub: @<username>
+**Author:** Warun Woraphoo — 67070563438 — GitHub: [@warunwora](https://github.com/warunwora) — Section 31
+**Peer reviewer:** Asamaporn Chayanuntasakul — 67070503448 — GitHub: [@asamapornch](https://github.com/asamapornch)
+
+Repository: https://github.com/warunwora/toktickit
+Project board: https://github.com/users/warunwora/projects/1
 
 ## Pull Requests I authored (reviewed by my partner)
-| PR | Branch | Reviewer verdict |
-|----|--------|------------------|
-|    | feature/1-project-foundation |  |
-|    | feature/2-health-check |  |
-|    | feature/3-category-seed |  |
-|    | feature/4-category-list |  |
 
-Reviewer comment I received: <...>
-How I responded: <...>
+| PR | Issue | Branch | Base | Reviewer verdict |
+|----|-------|--------|------|------------------|
+| [#5](https://github.com/warunwora/toktickit/pull/5) | #1 Project foundation | `feature/1-project-foundation` | `lab1-staging` | _pending_ |
+| [#6](https://github.com/warunwora/toktickit/pull/6) | #2 API health check | `feature/2-health-check` | `lab1-staging` | _pending_ |
+| [#7](https://github.com/warunwora/toktickit/pull/7) | #3 Category model and seed | `feature/3-category-seed` | `lab1-staging` | _pending_ |
+| [#8](https://github.com/warunwora/toktickit/pull/8) | #4 Category list | `feature/4-category-list` | `lab1-staging` | _pending_ |
+| _release_ | — | `lab1-staging` | `main` | _pending_ |
+
+**Reviewer comment I received:** _(paste my partner's actual review comment here)_
+
+**How I responded:** _(paste my reply and the commit/change it led to)_
 
 ## Pull Requests I reviewed for my partner
-My comment: <...>
-Partner's response: <...>
+
+| PR | Repository | My verdict |
+|----|------------|------------|
+| _link_ | _partner repo_ | _approved / changes requested_ |
+
+**My comment:** _(paste the review comment I gave)_
+
+**Partner's response:** _(paste how my partner replied and what they changed)_

--- a/docs/lab-01/tests.md
+++ b/docs/lab-01/tests.md
@@ -1,13 +1,57 @@
-# Lab 1 — Test Plan and Evidence  (fill this in)
+# Lab 1 — Test Plan and Evidence
 
-All test files live under server/tests/lab-01/ and client/tests/lab-01/.
+All test files live under `server/tests/lab-01/` and `client/tests/lab-01/`.
 
-| # | Tool | Test | Result |
-|---|------|------|--------|
-| 1 | Supertest | GET /api/health returns 200, status=ok | |
-| 2 | Supertest | GET /api/categories returns 4 seeded categories in id order | |
-| 3 | Vitest | Heading renders | |
-| 4 | Vitest | Success state shows Online + category list | |
-| 5 | Vitest | Error state shows Offline + message | |
+| Test | File (`tests/lab-01/`) | Tool | Test description | Result |
+|---|---|---|---|---|
+| API-01 | `server/tests/lab-01/health.test.ts` | Supertest | `GET /api/health` returns 200 and `{ status: "ok", service: "TokTickIT API" }` | Pass |
+| API-02 | `server/tests/lab-01/categories.test.ts` | Supertest | `GET /api/categories` returns the four seeded categories in id order, each with `id` and `name` | Pass |
+| UI-01 | `client/tests/lab-01/App.test.tsx` | Vitest | TokTickIT heading renders | Pass |
+| UI-02 | `client/tests/lab-01/App.test.tsx` | Vitest | Loading state (`⏳ loading…`, button disabled) changes to `Online` + the category list | Pass |
+| UI-03 | `client/tests/lab-01/App.test.tsx` | Vitest | API failure displays `Offline` and `Unable to connect to TokTickIT API` | Pass |
 
-Paste your passing terminal output / screenshot below.
+## How to run
+
+```bash
+cd server && npm test     # API-01, API-02 (requires the DB migrated and seeded)
+cd client && npm test     # UI-01, UI-02, UI-03
+```
+
+## Passing output (main branch)
+
+```
+> toktickit-server@1.0.0 test
+> vitest run
+
+ RUN  v2.1.9 .../toktickit/server
+
+ ✓ tests/lab-01/health.test.ts (1 test) 14ms
+ ✓ tests/lab-01/categories.test.ts (1 test) 106ms
+
+ Test Files  2 passed (2)
+      Tests  2 passed (2)
+```
+
+```
+> toktickit-client@1.0.0 test
+> vitest run
+
+ RUN  v2.1.9 .../toktickit/client
+
+ ✓ tests/lab-01/App.test.tsx (3 tests) 112ms
+
+ Test Files  1 passed (1)
+      Tests  3 passed (3)
+```
+
+> Replace the two blocks above with the terminal output captured on `main` after the release PR is
+> merged, and attach the screenshot of the same run.
+
+## Notes
+
+- API-02 reads the real PostgreSQL database through Prisma. Run `npx prisma migrate dev` and
+  `npm run prisma:seed` before the server tests.
+- UI-02 holds the mocked `checkSystem()` promise open so the loading state is asserted
+  deterministically before the resolved category list replaces it.
+- UI-03 mocks a rejected `checkSystem()`; the same path is what the browser shows when the database
+  container is stopped (verified manually with `docker stop toktickit-db`).


### PR DESCRIPTION
Fills in docs/lab-01/tests.md (5 tests, run instructions, passing output), reviewer.md (author + peer reviewer details, PR links), and ai_use.md (LLM used, 10 key prompts, reflection).

Review comments and the final main-branch terminal output are still marked as placeholders and will be filled once the PRs are reviewed and merged.