### PR TITLE
Lab 2 Issue 2: Data model, migration, and idempotent seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ Lab1_*.pdf
 Lab1_Starter_Scaffold.zip
 Lab1_Plan_Beginner.md
 CLAUDE_CODE_KICKOFF.md
+
+# uploaded attachments (local storage, never committed)
+server/uploads/
+
+# course docs (local only)
+Lab_0*.pdf
+Lab2_*.pdf

--- a/server/prisma/migrations/20260823154757_lab2_requester_ticketing/migration.sql
+++ b/server/prisma/migrations/20260823154757_lab2_requester_ticketing/migration.sql
@@ -1,0 +1,107 @@
+-- CreateEnum
+CREATE TYPE "Priority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW');
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RequesterUser" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "department" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RequesterUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "Priority" NOT NULL,
+    "status" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "storedFilename" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "uploadedByRequesterId" INTEGER NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removalReason" TEXT,
+    "removedByRequesterId" INTEGER,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RequesterUser_email_key" ON "RequesterUser"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_createdAt_idx" ON "Ticket"("requesterId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_status_idx" ON "Ticket"("requesterId", "status");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_categoryId_idx" ON "Ticket"("requesterId", "categoryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attachment_storedFilename_key" ON "Attachment"("storedFilename");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_removedAt_idx" ON "Attachment"("ticketId", "removedAt");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_uploadedByRequesterId_fkey" FOREIGN KEY ("uploadedByRequesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_removedByRequesterId_fkey" FOREIGN KEY ("removedByRequesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,5 +1,7 @@
 // Prisma schema — datasource and generator are pre-wired.
 // Your DATABASE_URL lives in server/.env (copy it from .env.example).
+//
+// The Lab 2 models follow docs/lab-02/specification.md §7 (Data Changes).
 
 generator client {
   provider = "prisma-client-js"
@@ -11,16 +13,107 @@ datasource db {
 }
 
 // ---------------------------------------------------------------------------
-// Issue 3 — Create and seed IT request categories
-// Define a Category model with:
-//   id        Int      @id @default(autoincrement())
-//   name      String   @unique
-//   createdAt DateTime @default(now())
-// Then run:  npx prisma migrate dev --name init
+// Reference data
 // ---------------------------------------------------------------------------
 
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+// ---------------------------------------------------------------------------
+// Development Requester — Lab 2 testing identity only (BR-05).
+// This is NOT authentication. Lab 3 replaces it with a real authenticated user.
+// ---------------------------------------------------------------------------
+
+model RequesterUser {
+  id         Int      @id @default(autoincrement())
+  name       String
+  email      String   @unique
+  department String?
+  isActive   Boolean  @default(true)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  tickets             Ticket[]
+  uploadedAttachments Attachment[] @relation("AttachmentUploader")
+  removedAttachments  Attachment[] @relation("AttachmentRemover")
+}
+
+// ---------------------------------------------------------------------------
+// Tickets
+// ---------------------------------------------------------------------------
+
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+// Single value in Lab 2 (BR-02). Lab 3 adds the rest of the lifecycle.
+enum TicketStatus {
+  NEW
+}
+
+model Ticket {
+  id                Int          @id @default(autoincrement())
+  ticketNumber      String       @unique
+  requesterId       Int
+  categoryId        Int
+  relatedSystemId   Int
+  summary           String
+  description       String
+  requestedPriority Priority
+  status            TicketStatus @default(NEW)
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
+
+  requester     RequesterUser @relation(fields: [requesterId], references: [id], onDelete: Restrict)
+  category      Category      @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  relatedSystem RelatedSystem @relation(fields: [relatedSystemId], references: [id], onDelete: Restrict)
+  attachments   Attachment[]
+
+  // My Tickets always filters by requester and sorts by createdAt desc (BR-14, BR-23).
+  @@index([requesterId, createdAt])
+  @@index([requesterId, status])
+  @@index([requesterId, categoryId])
+}
+
+// ---------------------------------------------------------------------------
+// Attachments — removal is always soft (BR-36). No row is ever deleted.
+// ---------------------------------------------------------------------------
+
+model Attachment {
+  id                    Int       @id @default(autoincrement())
+  ticketId              Int
+  originalFilename      String
+  storedFilename        String    @unique
+  mimeType              String
+  sizeBytes             Int
+  uploadedByRequesterId Int
+  uploadedAt            DateTime  @default(now())
+  removedAt             DateTime?
+  removalReason         String?
+  removedByRequesterId  Int?
+
+  ticket     Ticket         @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  uploadedBy RequesterUser  @relation("AttachmentUploader", fields: [uploadedByRequesterId], references: [id], onDelete: Restrict)
+  removedBy  RequesterUser? @relation("AttachmentRemover", fields: [removedByRequesterId], references: [id], onDelete: Restrict)
+
+  // Active-attachment count (BR-33) and the detail screen both read by ticket + removal state.
+  @@index([ticketId, removedAt])
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,14 +1,35 @@
 import { getPrisma } from "../src/prisma.js";
 
-// Issue 3 — seed the four supported categories.
-// The four names are: Account and Access, Hardware, Software, Network.
-// Requirement: running the seed twice must NOT create duplicates.
-// Hint: prisma.category.upsert({ where:{name}, update:{}, create:{name} }).
+// Lab 1 seeded the four categories. Lab 2 adds related systems and the
+// Development Requesters used instead of login (BR-05, BR-06).
+//
+// Every insert is an upsert on a natural unique key, so running the seed twice
+// creates no duplicates (docs/lab-02/specification.md §7.4).
+
+const CATEGORY_NAMES = ["Account and Access", "Hardware", "Software", "Network"];
+
+const RELATED_SYSTEM_NAMES = [
+  "Email",
+  "Campus Wi-Fi",
+  "VPN",
+  "LEB2 App",
+  "Grade Submission App",
+  "Printer",
+  "Corporate Laptop",
+];
+
+const REQUESTERS = [
+  { name: "Napat Srisai", email: "napat.sri@kmutt.ac.th", department: "Faculty of Engineering", isActive: true },
+  { name: "Chanya Pholrat", email: "chanya.pho@kmutt.ac.th", department: "Faculty of Science", isActive: true },
+  { name: "Kittisak Boonmee", email: "kittisak.boo@kmutt.ac.th", department: "Office of the Registrar", isActive: true },
+  { name: "Suphansa Wongchai", email: "suphansa.won@kmutt.ac.th", department: "Library", isActive: true },
+  { name: "Anan Tepsiri", email: "anan.tep@kmutt.ac.th", department: "Facilities (retired)", isActive: false },
+];
+
 async function main() {
   const prisma = getPrisma();
-  const names = ["Account and Access", "Hardware", "Software", "Network"];
 
-  for (const name of names) {
+  for (const name of CATEGORY_NAMES) {
     await prisma.category.upsert({
       where: { name },
       update: {},
@@ -16,7 +37,27 @@ async function main() {
     });
   }
 
-  console.log(`Seeded ${names.length} categories.`);
+  for (const name of RELATED_SYSTEM_NAMES) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+
+  for (const requester of REQUESTERS) {
+    await prisma.requesterUser.upsert({
+      where: { email: requester.email },
+      update: {},
+      create: requester,
+    });
+  }
+
+  const activeRequesters = REQUESTERS.filter((r) => r.isActive).length;
+  console.log(
+    `Seeded ${CATEGORY_NAMES.length} categories, ${RELATED_SYSTEM_NAMES.length} related systems, ` +
+      `${activeRequesters} active and ${REQUESTERS.length - activeRequesters} inactive Development Requester(s).`
+  );
 }
 
 main()


### PR DESCRIPTION
Implements docs/lab-02/specification.md §7.

**Models** — `RequesterUser`, `RelatedSystem`, `Ticket`, `Attachment`; `Category` gains `isActive` (additive, so the Lab 1 `/api/categories` contract keeps working). Enums `Priority` (LOW/MEDIUM/HIGH/URGENT) and `TicketStatus` (NEW only in Lab 2, BR-02).

**Relationships** — requester 1-n tickets, ticket 1-n attachments, category and related system reused by many tickets, all with foreign keys and `onDelete: Restrict` so reference data in use cannot be deleted. `Attachment` links to `RequesterUser` twice, as uploader and as remover, for the audit metadata BR-34 and BR-36 need.

**Indexes** — `Ticket(requesterId, createdAt)` is the justified one: every My Tickets query filters by requester and sorts by createdAt desc (BR-14, BR-23), so one composite index serves both. Plus `Ticket(requesterId, status)`, `Ticket(requesterId, categoryId)`, and `Attachment(ticketId, removedAt)` for the active-attachment count (BR-33).

**Soft removal** — `removedAt` / `removalReason` / `removedByRequesterId` are nullable columns; no delete path exists (BR-36).

**Seed** — 4 categories, 7 related systems, 4 active and 1 inactive Development Requester, all via `upsert` on natural unique keys.

## Verification
- `npx prisma migrate deploy` on a fresh empty database creates all five tables cleanly.
- Seed run twice: categories 4, relatedSystems 7, requesters 5 (4 active, 1 inactive), no duplicates.
- Lab 1 tests still pass (2/2), so the additive migration did not break the earlier contract.

Also ignores `server/uploads/` ahead of the attachment work so uploaded files can never be committed.

Closes #14