### PR TITLE
Lab 2 Issue 3: Reference APIs, Development Requester context, and Zen Green shell

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "bootstrap": "^5.3.3",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -1884,6 +1885,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -2751,6 +2765,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -2856,6 +2908,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "bootstrap": "^5.3.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/client/src/AppRoot.tsx
+++ b/client/src/AppRoot.tsx
@@ -1,0 +1,42 @@
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { RequesterProvider } from "./context/RequesterContext.js";
+import RequireRequester from "./components/RequireRequester.js";
+import AppShell from "./components/AppShell.js";
+import RequesterSelection from "./pages/RequesterSelection.js";
+import MyTickets from "./pages/MyTickets.js";
+import CreateTicket from "./pages/CreateTicket.js";
+import App from "./App.js";
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/select-requester" element={<RequesterSelection />} />
+
+      {/* Lab 1 vertical-slice page, kept reachable for its demo. */}
+      <Route path="/system-check" element={<App />} />
+
+      <Route
+        element={
+          <RequireRequester>
+            <AppShell />
+          </RequireRequester>
+        }
+      >
+        <Route path="/tickets" element={<MyTickets />} />
+        <Route path="/tickets/new" element={<CreateTicket />} />
+      </Route>
+
+      <Route path="*" element={<Navigate to="/tickets" replace />} />
+    </Routes>
+  );
+}
+
+export default function AppRoot() {
+  return (
+    <BrowserRouter>
+      <RequesterProvider>
+        <AppRoutes />
+      </RequesterProvider>
+    </BrowserRouter>
+  );
+}

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -1,0 +1,66 @@
+// One place that talks to the API, so Lab 3 can swap the Development Requester
+// header for a real credential without touching any screen (BR-43).
+
+export const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+
+export const REQUESTER_STORAGE_KEY = "toktickit.requesterId";
+
+export class ApiError extends Error {
+  status: number;
+  fields?: { field: string; message: string }[];
+
+  constructor(status: number, message: string, fields?: { field: string; message: string }[]) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.fields = fields;
+  }
+}
+
+export function getStoredRequesterId(): number | null {
+  const raw = window.localStorage.getItem(REQUESTER_STORAGE_KEY);
+  if (!raw) return null;
+  const id = Number(raw);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export function storeRequesterId(id: number): void {
+  window.localStorage.setItem(REQUESTER_STORAGE_KEY, String(id));
+}
+
+export function clearStoredRequesterId(): void {
+  window.localStorage.removeItem(REQUESTER_STORAGE_KEY);
+}
+
+interface RequestOptions extends RequestInit {
+  /** Send the selected Development Requester as X-Requester-Id (BR-07). */
+  withRequester?: boolean;
+}
+
+export async function apiFetch<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { withRequester = false, headers, ...rest } = options;
+  const finalHeaders = new Headers(headers);
+
+  if (withRequester) {
+    const requesterId = getStoredRequesterId();
+    if (requesterId !== null) finalHeaders.set("X-Requester-Id", String(requesterId));
+  }
+
+  const response = await fetch(`${API_URL}${path}`, { ...rest, headers: finalHeaders });
+
+  if (!response.ok) {
+    let message = "Something went wrong. Please try again.";
+    let fields: { field: string; message: string }[] | undefined;
+    try {
+      const body = await response.json();
+      if (typeof body?.error === "string") message = body.error;
+      if (Array.isArray(body?.fields)) fields = body.fields;
+    } catch {
+      // A non-JSON error body is still a failure; keep the generic message.
+    }
+    throw new ApiError(response.status, message, fields);
+  }
+
+  if (response.status === 204) return undefined as T;
+  return (await response.json()) as T;
+}

--- a/client/src/api/reference.ts
+++ b/client/src/api/reference.ts
@@ -1,0 +1,26 @@
+import { apiFetch } from "./client.js";
+
+export interface ReferenceItem {
+  id: number;
+  name: string;
+}
+
+export interface Requester {
+  id: number;
+  name: string;
+  email: string;
+  department: string | null;
+}
+
+export function getCategories(): Promise<ReferenceItem[]> {
+  return apiFetch<ReferenceItem[]>("/api/categories");
+}
+
+export function getRelatedSystems(): Promise<ReferenceItem[]> {
+  return apiFetch<ReferenceItem[]>("/api/related-systems");
+}
+
+/** Active Development Requesters only — the inactive one never appears (BR-06). */
+export function getRequesters(): Promise<Requester[]> {
+  return apiFetch<Requester[]>("/api/requesters");
+}

--- a/client/src/components/AppShell.tsx
+++ b/client/src/components/AppShell.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { Link, NavLink, Outlet } from "react-router-dom";
+import { useRequester } from "../context/RequesterContext.js";
+
+// Application shell — docs/lab-02/ui-spec.md §6.
+// Rendered only once a Development Requester is selected (BR-09).
+
+function navClass({ isActive }: { isActive: boolean }) {
+  return isActive ? "zg-nav-link zg-nav-link-active" : "zg-nav-link";
+}
+
+export default function AppShell() {
+  const { requester, changeRequester } = useRequester();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <>
+      <header className="zg-header">
+        <div className="zg-header-bar zg-page">
+          <div className="zg-header-left">
+            <Link to="/tickets" className="zg-brand">
+              TokTickIT
+            </Link>
+            <button
+              type="button"
+              className="zg-btn zg-btn-tertiary zg-menu-toggle"
+              aria-expanded={menuOpen}
+              aria-controls="zg-main-nav"
+              onClick={() => setMenuOpen((open) => !open)}
+            >
+              Menu
+            </button>
+          </div>
+
+          <nav id="zg-main-nav" aria-label="Main" className={menuOpen ? "zg-nav zg-nav-open" : "zg-nav"}>
+            <NavLink to="/tickets" end className={navClass} onClick={() => setMenuOpen(false)}>
+              My Tickets
+            </NavLink>
+            <NavLink to="/tickets/new" className={navClass} onClick={() => setMenuOpen(false)}>
+              Create Ticket
+            </NavLink>
+          </nav>
+
+          <div className="zg-header-identity">
+            <span>
+              <span className="visually-hidden">Development Requester: </span>
+              {requester?.name}
+            </span>
+            <button type="button" className="zg-btn zg-btn-tertiary" onClick={changeRequester}>
+              Change Requester
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <Outlet />
+    </>
+  );
+}

--- a/client/src/components/RequireRequester.tsx
+++ b/client/src/components/RequireRequester.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from "react";
+import { useRequester } from "../context/RequesterContext.js";
+import RequesterSelection from "../pages/RequesterSelection.js";
+
+// BR-09 / AC-01 — no Development Requester selected means no ticket screen.
+export default function RequireRequester({ children }: { children: ReactNode }) {
+  const { requester, loading } = useRequester();
+
+  if (loading) {
+    return (
+      <main className="zg-page">
+        <p role="status" aria-live="polite">
+          Loading…
+        </p>
+      </main>
+    );
+  }
+
+  if (!requester) return <RequesterSelection />;
+
+  return <>{children}</>;
+}

--- a/client/src/context/RequesterContext.tsx
+++ b/client/src/context/RequesterContext.tsx
@@ -1,0 +1,99 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, ReactNode } from "react";
+import { clearStoredRequesterId, getStoredRequesterId, storeRequesterId } from "../api/client.js";
+import { getRequesters, Requester } from "../api/reference.js";
+
+// The selected Development Requester is the Lab 2 testing identity (BR-05).
+// It is NOT authentication: it lives in localStorage and is sent as a header.
+
+interface RequesterContextValue {
+  requester: Requester | null;
+  /** Bumped on every change so requester-scoped screens can reload (BR-08). */
+  version: number;
+  loading: boolean;
+  selectRequester: (requester: Requester) => void;
+  changeRequester: () => void;
+  /** Set when a stored selection turned out to be gone or inactive (BR-10). */
+  staleSelectionMessage: string | null;
+  clearStaleSelectionMessage: () => void;
+}
+
+const RequesterContext = createContext<RequesterContextValue | null>(null);
+
+export function RequesterProvider({ children }: { children: ReactNode }) {
+  const [requester, setRequester] = useState<Requester | null>(null);
+  const [version, setVersion] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [staleSelectionMessage, setStaleSelectionMessage] = useState<string | null>(null);
+
+  // Re-resolve a stored id against the active requesters on start-up, so a
+  // requester that was deactivated cannot keep a session alive (BR-10).
+  useEffect(() => {
+    const storedId = getStoredRequesterId();
+    if (storedId === null) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    getRequesters()
+      .then((requesters) => {
+        if (cancelled) return;
+        const match = requesters.find((r) => r.id === storedId);
+        if (match) {
+          setRequester(match);
+        } else {
+          clearStoredRequesterId();
+          setStaleSelectionMessage(
+            "The Development Requester you were using is no longer available. Please select another one."
+          );
+        }
+      })
+      .catch(() => {
+        // Leave the selection in storage: a network blip must not force a reselect.
+        if (!cancelled) setRequester(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectRequester = useCallback((next: Requester) => {
+    storeRequesterId(next.id);
+    setRequester(next);
+    setStaleSelectionMessage(null);
+    setVersion((v) => v + 1);
+  }, []);
+
+  const changeRequester = useCallback(() => {
+    clearStoredRequesterId();
+    setRequester(null);
+    setVersion((v) => v + 1);
+  }, []);
+
+  const clearStaleSelectionMessage = useCallback(() => setStaleSelectionMessage(null), []);
+
+  const value = useMemo(
+    () => ({
+      requester,
+      version,
+      loading,
+      selectRequester,
+      changeRequester,
+      staleSelectionMessage,
+      clearStaleSelectionMessage,
+    }),
+    [requester, version, loading, selectRequester, changeRequester, staleSelectionMessage, clearStaleSelectionMessage]
+  );
+
+  return <RequesterContext.Provider value={value}>{children}</RequesterContext.Provider>;
+}
+
+export function useRequester(): RequesterContextValue {
+  const context = useContext(RequesterContext);
+  if (!context) throw new Error("useRequester must be used inside a RequesterProvider");
+  return context;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "bootstrap/dist/css/bootstrap.min.css";
-import App from "./App.js";
+import "./styles/zen-green.css";
+import AppRoot from "./AppRoot.js";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <AppRoot />
   </React.StrictMode>
 );

--- a/client/src/pages/CreateTicket.tsx
+++ b/client/src/pages/CreateTicket.tsx
@@ -1,0 +1,12 @@
+// Implemented in Lab 2 Issue 4 (feature/lab2-4-create-ticket).
+export default function CreateTicket() {
+  return (
+    <main className="zg-page">
+      <h1 className="zg-page-title">Create Ticket</h1>
+      <div className="zg-callout zg-callout-info" role="status">
+        The Create Ticket form arrives with Issue 4. The Development Requester context and navigation
+        are in place.
+      </div>
+    </main>
+  );
+}

--- a/client/src/pages/MyTickets.tsx
+++ b/client/src/pages/MyTickets.tsx
@@ -1,0 +1,12 @@
+// Implemented in Lab 2 Issue 5 (feature/lab2-5-my-tickets).
+export default function MyTickets() {
+  return (
+    <main className="zg-page">
+      <h1 className="zg-page-title">My Tickets</h1>
+      <div className="zg-callout zg-callout-info" role="status">
+        The ticket list arrives with Issue 5. The Development Requester context and navigation are in
+        place.
+      </div>
+    </main>
+  );
+}

--- a/client/src/pages/RequesterSelection.tsx
+++ b/client/src/pages/RequesterSelection.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getRequesters, Requester } from "../api/reference.js";
+import { useRequester } from "../context/RequesterContext.js";
+
+// Development Requester Selection — docs/lab-02/ui-spec.md §7.1.
+// This is a Lab 2 testing mechanism, not a login screen (BR-05, BR-44).
+
+type LoadState = "loading" | "ready" | "empty" | "failed";
+
+export default function RequesterSelection() {
+  const [state, setState] = useState<LoadState>("loading");
+  const [requesters, setRequesters] = useState<Requester[]>([]);
+  const [selectedId, setSelectedId] = useState("");
+  const [reloadToken, setReloadToken] = useState(0);
+  const { selectRequester, staleSelectionMessage, clearStaleSelectionMessage } = useRequester();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let cancelled = false;
+    setState("loading");
+
+    getRequesters()
+      .then((list) => {
+        if (cancelled) return;
+        setRequesters(list);
+        setState(list.length === 0 ? "empty" : "ready");
+      })
+      .catch(() => {
+        if (!cancelled) setState("failed");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  function handleContinue() {
+    const chosen = requesters.find((r) => String(r.id) === selectedId);
+    if (!chosen) return;
+    clearStaleSelectionMessage();
+    selectRequester(chosen);
+    navigate("/tickets");
+  }
+
+  return (
+    <main className="zg-page" style={{ maxWidth: 480 }}>
+      <div className="zg-card">
+        <h1 className="zg-page-title">TokTickIT</h1>
+
+        <p className="zg-muted">
+          Select a Development Requester to test requester-specific ticket behavior. This is not a
+          login screen. Authentication and role-based access will be introduced in Lab 3.
+        </p>
+
+        {staleSelectionMessage && (
+          <div className="zg-callout zg-callout-warning" role="status">
+            {staleSelectionMessage}
+          </div>
+        )}
+
+        {state === "loading" && (
+          <p role="status" aria-live="polite">
+            Loading requesters…
+          </p>
+        )}
+
+        {state === "empty" && (
+          <div className="zg-callout zg-callout-warning" role="status">
+            <p className="mb-2">No active Development Requesters found. Run the seed and reload.</p>
+            <button type="button" className="zg-btn zg-btn-secondary" onClick={() => setReloadToken((t) => t + 1)}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {state === "failed" && (
+          <div className="zg-callout zg-callout-error" role="alert">
+            <p className="mb-2">Unable to load Development Requesters.</p>
+            <button type="button" className="zg-btn zg-btn-secondary" onClick={() => setReloadToken((t) => t + 1)}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {state === "ready" && (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleContinue();
+            }}
+          >
+            <div className="zg-field">
+              <label className="zg-label" htmlFor="requester">
+                Development Requester
+                <span className="zg-required" aria-hidden="true">
+                  *
+                </span>
+              </label>
+              <select
+                id="requester"
+                className="zg-select"
+                required
+                aria-required="true"
+                value={selectedId}
+                onChange={(event) => setSelectedId(event.target.value)}
+              >
+                <option value="">Select a Development Requester…</option>
+                {requesters.map((requester) => (
+                  <option key={requester.id} value={requester.id}>
+                    {requester.department ? `${requester.name} — ${requester.department}` : requester.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <button type="submit" className="zg-btn zg-btn-primary" disabled={selectedId === ""}>
+              Continue
+            </button>
+          </form>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/client/src/styles/zen-green.css
+++ b/client/src/styles/zen-green.css
@@ -1,0 +1,372 @@
+/* Zen Green theme — docs/lab-02/ui-spec.md §1–§5.
+   Tokens are declared once here; no component hard-codes a hex value. */
+
+:root {
+  --zg-primary: #006b3c;
+  --zg-secondary: #0b7a46;
+  --zg-pale: #eaf6ef;
+  --zg-bg: #f5f7f6;
+  --zg-surface: #ffffff;
+  --zg-border: #d8e1dc;
+  --zg-text: #1b2b22;
+  --zg-text-muted: #5a6b62;
+  --zg-readonly-bg: #edf1ee;
+  --zg-error: #a4161a;
+  --zg-error-bg: #fdecec;
+  --zg-warning: #b26b00;
+  --zg-warning-bg: #fff4e0;
+  --zg-success: #0b7a46;
+  --zg-success-bg: #eaf6ef;
+  --zg-focus: #0b7a46;
+
+  --zg-space-1: 4px;
+  --zg-space-2: 8px;
+  --zg-space-3: 12px;
+  --zg-space-4: 16px;
+  --zg-space-6: 24px;
+  --zg-space-8: 32px;
+  --zg-space-12: 48px;
+
+  --zg-radius: 8px;
+  --zg-max-width: 1120px;
+}
+
+body {
+  background-color: var(--zg-bg);
+  color: var(--zg-text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  line-height: 1.5;
+}
+
+/* ---------- layout ---------- */
+
+.zg-page {
+  max-width: var(--zg-max-width);
+  margin: 0 auto;
+  padding: var(--zg-space-6) var(--zg-space-4);
+}
+
+.zg-card {
+  background: var(--zg-surface);
+  border: 1px solid var(--zg-border);
+  border-radius: var(--zg-radius);
+  box-shadow: 0 1px 2px rgba(27, 43, 34, 0.06);
+  padding: var(--zg-space-6);
+}
+
+@media (max-width: 767px) {
+  .zg-card {
+    padding: var(--zg-space-4);
+  }
+}
+
+.zg-page-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: var(--zg-space-4);
+}
+
+.zg-section-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: var(--zg-space-3);
+}
+
+.zg-muted {
+  color: var(--zg-text-muted);
+  font-size: 0.8125rem;
+}
+
+/* ---------- application shell ---------- */
+
+.zg-header {
+  background: var(--zg-primary);
+  color: #fff;
+}
+
+.zg-header a,
+.zg-header .zg-btn-tertiary,
+.zg-header .zg-header-identity {
+  color: #fff;
+}
+
+.zg-header-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--zg-space-3);
+  padding-top: var(--zg-space-2);
+  padding-bottom: var(--zg-space-2);
+}
+
+.zg-header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--zg-space-3);
+}
+
+.zg-header-identity {
+  display: flex;
+  align-items: center;
+  gap: var(--zg-space-2);
+}
+
+.zg-brand {
+  font-weight: 600;
+  font-size: 1.125rem;
+  text-decoration: none;
+}
+
+.zg-nav {
+  display: none;
+  gap: var(--zg-space-2);
+}
+
+.zg-nav-open {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  order: 3;
+}
+
+.zg-nav-link {
+  display: inline-block;
+  padding: var(--zg-space-2) var(--zg-space-3);
+  text-decoration: none;
+  border-bottom: 3px solid transparent;
+}
+
+.zg-nav-link:hover {
+  border-bottom-color: rgba(255, 255, 255, 0.4);
+}
+
+.zg-nav-link.zg-nav-link-active {
+  border-bottom-color: var(--zg-pale);
+  font-weight: 600;
+}
+
+/* Desktop and tablet: the navigation is always visible, the toggle is not. */
+@media (min-width: 992px) {
+  .zg-nav {
+    display: flex;
+    flex-direction: row;
+    width: auto;
+    order: 0;
+  }
+
+  .zg-header .zg-menu-toggle {
+    display: none;
+  }
+}
+
+/* ---------- form controls ---------- */
+
+.zg-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--zg-text);
+  margin-bottom: var(--zg-space-2);
+}
+
+.zg-required {
+  color: var(--zg-error);
+  margin-left: 2px;
+}
+
+.zg-field {
+  margin-bottom: var(--zg-space-4);
+}
+
+.zg-input,
+.zg-select,
+.zg-textarea {
+  width: 100%;
+  min-height: 40px;
+  padding: var(--zg-space-2) var(--zg-space-3);
+  background: var(--zg-surface);
+  color: var(--zg-text);
+  border: 1px solid var(--zg-border);
+  border-radius: var(--zg-radius);
+  font-size: 1rem;
+}
+
+.zg-textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.zg-input:focus,
+.zg-select:focus,
+.zg-textarea:focus,
+.zg-btn:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--zg-focus);
+  outline-offset: 2px;
+}
+
+.zg-readonly {
+  background: var(--zg-readonly-bg);
+  color: var(--zg-text);
+}
+
+.zg-invalid {
+  border-color: var(--zg-error);
+}
+
+.zg-input:disabled,
+.zg-select:disabled,
+.zg-textarea:disabled {
+  background: var(--zg-readonly-bg);
+  color: var(--zg-text-muted);
+  cursor: not-allowed;
+}
+
+.zg-message {
+  display: block;
+  margin-top: var(--zg-space-1);
+  font-size: 0.8125rem;
+}
+
+.zg-message-error {
+  color: var(--zg-error);
+}
+
+/* ---------- buttons ---------- */
+
+.zg-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--zg-space-2);
+  min-height: 44px;
+  padding: var(--zg-space-2) var(--zg-space-4);
+  border-radius: var(--zg-radius);
+  border: 1px solid transparent;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.zg-btn-primary {
+  background: var(--zg-primary);
+  color: #fff;
+}
+
+.zg-btn-primary:hover:not(:disabled) {
+  background: var(--zg-secondary);
+}
+
+.zg-btn-secondary {
+  background: var(--zg-surface);
+  color: var(--zg-primary);
+  border-color: var(--zg-primary);
+}
+
+.zg-btn-tertiary {
+  background: transparent;
+  color: var(--zg-secondary);
+  border-color: transparent;
+  text-decoration: underline;
+}
+
+.zg-btn-destructive {
+  background: var(--zg-surface);
+  color: var(--zg-error);
+  border-color: var(--zg-error);
+}
+
+.zg-btn:disabled {
+  background: var(--zg-readonly-bg);
+  color: var(--zg-text-muted);
+  border-color: var(--zg-border);
+  cursor: not-allowed;
+}
+
+/* ---------- callouts ---------- */
+
+.zg-callout {
+  border: 1px solid;
+  border-radius: var(--zg-radius);
+  padding: var(--zg-space-4);
+  margin-bottom: var(--zg-space-4);
+}
+
+.zg-callout-error {
+  background: var(--zg-error-bg);
+  border-color: var(--zg-error);
+  color: var(--zg-error);
+}
+
+.zg-callout-warning {
+  background: var(--zg-warning-bg);
+  border-color: var(--zg-warning);
+  color: var(--zg-warning);
+}
+
+.zg-callout-success {
+  background: var(--zg-success-bg);
+  border-color: var(--zg-success);
+  color: var(--zg-text);
+}
+
+.zg-callout-info {
+  background: var(--zg-pale);
+  border-color: var(--zg-border);
+  color: var(--zg-text);
+}
+
+/* ---------- badges ---------- */
+
+.zg-badge {
+  display: inline-block;
+  padding: 2px var(--zg-space-3);
+  border: 1px solid var(--zg-border);
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+
+.zg-badge-status-new {
+  background: var(--zg-pale);
+  color: var(--zg-primary);
+  border-color: var(--zg-primary);
+}
+
+.zg-badge-priority-low {
+  background: #f1f3f2;
+  color: #46534c;
+}
+
+.zg-badge-priority-medium {
+  background: #e9eef3;
+  color: #33495c;
+}
+
+.zg-badge-priority-high {
+  background: var(--zg-warning-bg);
+  color: var(--zg-warning);
+  border-color: var(--zg-warning);
+}
+
+.zg-badge-priority-urgent {
+  background: var(--zg-error-bg);
+  color: var(--zg-error);
+  border-color: var(--zg-error);
+}
+
+.zg-badge-active {
+  background: var(--zg-success-bg);
+  color: var(--zg-success);
+  border-color: var(--zg-success);
+}
+
+.zg-badge-removed {
+  background: var(--zg-readonly-bg);
+  color: var(--zg-text-muted);
+}
+
+.zg-badge-unavailable {
+  background: var(--zg-warning-bg);
+  color: var(--zg-warning);
+  border-color: var(--zg-warning);
+}

--- a/client/tests/lab-02/AppShell.test.tsx
+++ b/client/tests/lab-02/AppShell.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import * as reference from "../../src/api/reference.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import { AppRoutes } from "../../src/AppRoot.js";
+import { REQUESTER_STORAGE_KEY } from "../../src/api/client.js";
+
+// UI-03 — docs/lab-02/tests.md §2.3
+
+const ACTIVE_REQUESTERS = [
+  { id: 1, name: "Napat Srisai", email: "napat.sri@kmutt.ac.th", department: "Faculty of Engineering" },
+  { id: 2, name: "Chanya Pholrat", email: "chanya.pho@kmutt.ac.th", department: "Faculty of Science" },
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.spyOn(reference, "getRequesters").mockResolvedValue(ACTIVE_REQUESTERS);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderApp(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <RequesterProvider>
+        <AppRoutes />
+      </RequesterProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("application shell", () => {
+  // UI-03 / AC-03
+  it("shows the selected Development Requester and the navigation on every ticket screen", async () => {
+    window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+
+    renderApp("/tickets");
+
+    expect(await screen.findByText("Napat Srisai")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /my tickets/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /create ticket/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /change requester/i })).toBeInTheDocument();
+  });
+
+  // UI-03 / ui-spec §6 — active page indication is not colour alone
+  it("marks the current page with aria-current and the active class", async () => {
+    window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+
+    renderApp("/tickets/new");
+
+    const createLink = await screen.findByRole("link", { name: /create ticket/i });
+    expect(createLink).toHaveAttribute("aria-current", "page");
+    expect(createLink.className).toContain("zg-nav-link-active");
+
+    const listLink = screen.getByRole("link", { name: /my tickets/i });
+    expect(listLink).not.toHaveAttribute("aria-current");
+  });
+
+  // UI-03 / AC-04, BR-08
+  it("returns to the selection screen and clears the stored identity on Change Requester", async () => {
+    window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+
+    renderApp("/tickets");
+
+    await userEvent.click(await screen.findByRole("button", { name: /change requester/i }));
+
+    expect(await screen.findByText(/this is not a login screen/i)).toBeInTheDocument();
+    expect(window.localStorage.getItem(REQUESTER_STORAGE_KEY)).toBeNull();
+    expect(screen.queryByRole("link", { name: /my tickets/i })).not.toBeInTheDocument();
+  });
+
+  // UI-03 / AC-04 — the new identity is the one the shell reports
+  it("shows the newly selected requester after switching", async () => {
+    window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+
+    renderApp("/tickets");
+
+    await userEvent.click(await screen.findByRole("button", { name: /change requester/i }));
+    await userEvent.selectOptions(
+      await screen.findByRole("combobox", { name: /development requester/i }),
+      "2"
+    );
+    await userEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(await screen.findByText("Chanya Pholrat")).toBeInTheDocument();
+    expect(screen.queryByText("Napat Srisai")).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(REQUESTER_STORAGE_KEY)).toBe("2");
+  });
+});

--- a/client/tests/lab-02/RequesterSelection.test.tsx
+++ b/client/tests/lab-02/RequesterSelection.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import * as reference from "../../src/api/reference.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import RequireRequester from "../../src/components/RequireRequester.js";
+import RequesterSelection from "../../src/pages/RequesterSelection.js";
+import { REQUESTER_STORAGE_KEY } from "../../src/api/client.js";
+
+// UI-01, UI-02 — docs/lab-02/tests.md §2.3
+
+const ACTIVE_REQUESTERS = [
+  { id: 1, name: "Napat Srisai", email: "napat.sri@kmutt.ac.th", department: "Faculty of Engineering" },
+  { id: 2, name: "Chanya Pholrat", email: "chanya.pho@kmutt.ac.th", department: "Faculty of Science" },
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderSelection() {
+  return render(
+    <MemoryRouter initialEntries={["/select-requester"]}>
+      <RequesterProvider>
+        <Routes>
+          <Route path="/select-requester" element={<RequesterSelection />} />
+          <Route path="/tickets" element={<h1>My Tickets</h1>} />
+        </Routes>
+      </RequesterProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("Development Requester Selection", () => {
+  // UI-01 / AC-02, BR-06
+  it("lists active requesters and states that it is not a login screen", async () => {
+    vi.spyOn(reference, "getRequesters").mockResolvedValue(ACTIVE_REQUESTERS);
+
+    renderSelection();
+
+    expect(await screen.findByRole("combobox", { name: /development requester/i })).toBeInTheDocument();
+    expect(screen.getByText(/this is not a login screen/i)).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Napat Srisai/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Anan Tepsiri/ })).not.toBeInTheDocument();
+  });
+
+  // UI-01 / AC-11-style busy rule: Continue stays disabled until a choice is made
+  it("keeps Continue disabled until a requester is chosen, then stores the selection", async () => {
+    vi.spyOn(reference, "getRequesters").mockResolvedValue(ACTIVE_REQUESTERS);
+
+    renderSelection();
+
+    const continueButton = await screen.findByRole("button", { name: /continue/i });
+    expect(continueButton).toBeDisabled();
+
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /development requester/i }),
+      "2"
+    );
+    expect(continueButton).toBeEnabled();
+
+    await userEvent.click(continueButton);
+
+    expect(window.localStorage.getItem(REQUESTER_STORAGE_KEY)).toBe("2");
+    expect(await screen.findByRole("heading", { name: /my tickets/i })).toBeInTheDocument();
+  });
+
+  // UI-01 / AC-06
+  it("shows an empty state instead of an empty dropdown when no active requester exists", async () => {
+    vi.spyOn(reference, "getRequesters").mockResolvedValue([]);
+
+    renderSelection();
+
+    expect(await screen.findByText(/no active development requesters found/i)).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  // UI-01 / AC-05
+  it("shows a safe failure state with retry when the requester API fails", async () => {
+    vi.spyOn(reference, "getRequesters").mockRejectedValue(new Error("network down"));
+
+    renderSelection();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/unable to load development requesters/i);
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("retries loading when Retry is pressed", async () => {
+    const spy = vi
+      .spyOn(reference, "getRequesters")
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(ACTIVE_REQUESTERS);
+
+    renderSelection();
+
+    await userEvent.click(await screen.findByRole("button", { name: /retry/i }));
+
+    expect(await screen.findByRole("combobox", { name: /development requester/i })).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("RequireRequester guard", () => {
+  // UI-02 / AC-01, BR-09
+  it("shows the selection screen when no requester is selected", async () => {
+    vi.spyOn(reference, "getRequesters").mockResolvedValue(ACTIVE_REQUESTERS);
+
+    render(
+      <MemoryRouter initialEntries={["/tickets"]}>
+        <RequesterProvider>
+          <RequireRequester>
+            <h1>My Tickets</h1>
+          </RequireRequester>
+        </RequesterProvider>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/this is not a login screen/i)).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /my tickets/i })).not.toBeInTheDocument();
+  });
+
+  // UI-02 / BR-10
+  it("clears a stored requester that is no longer active and explains why", async () => {
+    window.localStorage.setItem(REQUESTER_STORAGE_KEY, "99");
+    vi.spyOn(reference, "getRequesters").mockResolvedValue(ACTIVE_REQUESTERS);
+
+    render(
+      <MemoryRouter initialEntries={["/tickets"]}>
+        <RequesterProvider>
+          <RequireRequester>
+            <h1>My Tickets</h1>
+          </RequireRequester>
+        </RequesterProvider>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/no longer available/i)).toBeInTheDocument();
+    expect(window.localStorage.getItem(REQUESTER_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/client/tests/setup.ts
+++ b/client/tests/setup.ts
@@ -1,1 +1,20 @@
 import "@testing-library/jest-dom";
+
+// This jsdom build exposes a `localStorage` accessor that resolves to undefined,
+// so tests get a minimal in-memory implementation. Real browsers always provide
+// the API; only the test environment needs this shim.
+if (!window.localStorage) {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => void store.delete(key),
+    setItem: (key, value) => void store.set(key, String(value)),
+  };
+
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,40 +1,20 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
-import { getPrisma } from "./prisma.js";
+import { referenceRouter } from "./routes/reference.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
 export const app = express();
 
-app.use(cors());          // already wired: lets the Vite dev server call this API
+app.use(cors());          // lets the Vite dev server call this API
 app.use(express.json());
 
-// ---------------------------------------------------------------------------
-// Issue 2 — API health check
-// Make the test in tests/lab-01/health.test.ts pass.
-// It must return HTTP 200 with JSON: { status: "ok", service: "TokTickIT API" }
-// ---------------------------------------------------------------------------
+// Lab 1 — health check.
 app.get("/api/health", (_req: Request, res: Response) => {
   res.status(200).json({ status: "ok", service: "TokTickIT API" });
 });
 
-// ---------------------------------------------------------------------------
-// Issue 4 — Category list
-// Add:  GET /api/categories
-//   -> read categories from PostgreSQL via getPrisma().category.findMany(...)
-//   -> return each { id, name } in a predictable (id) order
-//   -> on failure, respond 500 with a safe message (no internal details)
-// ---------------------------------------------------------------------------
-app.get("/api/categories", async (_req: Request, res: Response) => {
-  try {
-    const categories = await getPrisma().category.findMany({
-      select: { id: true, name: true },
-      orderBy: { id: "asc" },
-    });
-    res.status(200).json(categories);
-  } catch {
-    res.status(500).json({ error: "Unable to load categories" });
-  }
-});
+// Lab 2 — reference data: categories, related systems, Development Requesters.
+app.use(referenceRouter);
 
 export default app;

--- a/server/src/routes/reference.ts
+++ b/server/src/routes/reference.ts
@@ -1,0 +1,51 @@
+import { Router, Request, Response } from "express";
+import { getPrisma } from "../prisma.js";
+
+// Reference data used by the Create Ticket form, the My Tickets filters, and the
+// Development Requester selector.
+// Contract: docs/lab-02/api-spec.md §2.
+
+export const referenceRouter = Router();
+
+// Lab 1 contract preserved: a bare array of { id, name } in id order (D-09).
+// Lab 2 only narrows it to active rows.
+referenceRouter.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const categories = await getPrisma().category.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true },
+      orderBy: { id: "asc" },
+    });
+    res.status(200).json(categories);
+  } catch {
+    res.status(500).json({ error: "Unable to load categories" });
+  }
+});
+
+referenceRouter.get("/api/related-systems", async (_req: Request, res: Response) => {
+  try {
+    const relatedSystems = await getPrisma().relatedSystem.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true },
+      orderBy: { id: "asc" },
+    });
+    res.status(200).json(relatedSystems);
+  } catch {
+    res.status(500).json({ error: "Unable to load related systems" });
+  }
+});
+
+// Active Development Requesters only (BR-06). This endpoint is the one place the
+// tester picks an identity, so it deliberately needs no X-Requester-Id header.
+referenceRouter.get("/api/requesters", async (_req: Request, res: Response) => {
+  try {
+    const requesters = await getPrisma().requesterUser.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true, email: true, department: true },
+      orderBy: { id: "asc" },
+    });
+    res.status(200).json(requesters);
+  } catch {
+    res.status(500).json({ error: "Unable to load Development Requesters" });
+  }
+});

--- a/server/tests/lab-02/reference.api.test.ts
+++ b/server/tests/lab-02/reference.api.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+
+// API-29, API-30, API-31 — docs/lab-02/tests.md §2.2
+// Requires the database to be migrated and seeded (npm run prisma:seed).
+
+describe("GET /api/categories and /api/related-systems", () => {
+  // API-30 / AC-15
+  it("returns the seeded active categories from the database", async () => {
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThanOrEqual(4);
+    expect(res.body.map((c: { name: string }) => c.name)).toEqual(
+      expect.arrayContaining(["Account and Access", "Hardware", "Software", "Network"])
+    );
+    expect(Object.keys(res.body[0]).sort()).toEqual(["id", "name"]);
+  });
+
+  // API-30 / AC-15
+  it("returns at least six active related systems in id order", async () => {
+    const res = await request(app).get("/api/related-systems");
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThanOrEqual(6);
+    expect(res.body.map((s: { name: string }) => s.name)).toEqual(
+      expect.arrayContaining(["Email", "Campus Wi-Fi", "VPN", "Printer"])
+    );
+
+    const ids = res.body.map((s: { id: number }) => s.id);
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+  });
+});
+
+describe("GET /api/requesters", () => {
+  // API-29 / AC-02, BR-06
+  it("returns only active Development Requesters", async () => {
+    const res = await request(app).get("/api/requesters");
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThanOrEqual(4);
+
+    const names = res.body.map((r: { name: string }) => r.name);
+    expect(names).toContain("Napat Srisai");
+    expect(names).not.toContain("Anan Tepsiri"); // the seeded inactive requester
+  });
+
+  it("exposes the fields the selector needs and nothing else", async () => {
+    const res = await request(app).get("/api/requesters");
+
+    expect(Object.keys(res.body[0]).sort()).toEqual(["department", "email", "id", "name"]);
+  });
+});
+
+describe("safe error handling", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../../src/prisma.js");
+  });
+
+  // API-31 / BR-28
+  it("returns a generic message and leaks no internals when the database fails", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/prisma.js", () => ({
+      getPrisma: () => {
+        throw new Error("connect ECONNREFUSED 127.0.0.1:5432 at PrismaClient._request");
+      },
+    }));
+
+    const { app: failingApp } = await import("../../src/app.js");
+    const res = await request(failingApp).get("/api/requesters");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Unable to load Development Requesters" });
+    expect(JSON.stringify(res.body)).not.toMatch(/Prisma|ECONNREFUSED|5432|at |\//);
+  });
+});


### PR DESCRIPTION
Implements api-spec.md §2 and ui-spec.md §1–§7.1.

**Backend** — `GET /api/related-systems` and `GET /api/requesters` (active rows only), plus `GET /api/categories` narrowed to active rows while keeping the Lab 1 array shape (D-09). Routes moved into `server/src/routes/reference.ts` so `app.ts` stays a wiring file as the surface grows.

**Frontend**
- `styles/zen-green.css` — every token from ui-spec §1 declared once; no component hard-codes a hex value.
- `api/client.ts` — one `apiFetch` that attaches `X-Requester-Id` and normalises errors into `ApiError`, so Lab 3 swaps the header for a real credential in one file (BR-43).
- `context/RequesterContext.tsx` — selection stored in `localStorage`, re-resolved against the active requesters on start-up so a deactivated requester cannot keep a session alive (BR-10).
- `RequesterSelection` — the "this is not a login screen" copy, active-requester dropdown, Continue disabled until chosen, and loading / empty / failure states with Retry.
- `AppShell` + `RequireRequester` — header, My Tickets / Create Ticket navigation with `aria-current`, requester name, Change Requester, mobile menu, and the guard that sends an unselected user back to the selector (BR-09).
- My Tickets and Create Ticket are placeholders until Issues 4 and 5.

**Dependency added:** `react-router-dom`. The stack constraint fixes the framework, database, ORM and UI library; routing is needed because ticket detail is addressed by URL and the ownership rule is about direct URL access. No UI library was substituted — Bootstrap still provides the base and Zen Green layers on top.

## Verification
- Server: 7/7 pass (`reference.api.test.ts` covers API-29, API-30, API-31 including the safe-error check that no Prisma or connection detail leaks).
- Client: 14/14 pass (`RequesterSelection.test.tsx` UI-01/UI-02, `AppShell.test.tsx` UI-03), Lab 1 tests still green.
- `tsc --noEmit` clean on both sides.
- Manual: `/tickets` with no selection shows the selector; the inactive seeded requester (Anan Tepsiri) is absent from the dropdown and from `/api/requesters`; after Continue the shell shows the name and `localStorage` holds the id; desktop 1280 shows the inline nav, mobile 390 shows the menu toggle with no horizontal scroll.

One test-infrastructure note: Node 26 exposes a `localStorage` global that shadows jsdom's, so `client/tests/setup.ts` installs a small in-memory shim when `window.localStorage` is missing. Browsers are unaffected.

Closes #15