### PR TITLE
Lab 2 Issue 5: My Tickets API and screen

### DIFF
--- a/client/src/api/tickets.ts
+++ b/client/src/api/tickets.ts
@@ -39,3 +39,49 @@ export function createTicket(payload: CreateTicketPayload): Promise<Ticket> {
     body: JSON.stringify(payload),
   });
 }
+
+export interface TicketListItem {
+  id: number;
+  ticketNumber: string;
+  summary: string;
+  category: TicketReference;
+  relatedSystem: TicketReference;
+  requestedPriority: Priority;
+  status: TicketStatus;
+  attachmentCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TicketListResponse {
+  items: TicketListItem[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export interface TicketListParams {
+  search?: string;
+  categoryId?: string;
+  relatedSystemId?: string;
+  requestedPriority?: string;
+  status?: string;
+  sort?: string;
+  order?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+/** Only non-empty parameters are sent: the API rejects unknown ones (BR-25). */
+export function listTickets(params: TicketListParams): Promise<TicketListResponse> {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") continue;
+    query.set(key, String(value));
+  }
+  const suffix = query.toString();
+  return apiFetch<TicketListResponse>(`/api/tickets${suffix ? `?${suffix}` : ""}`, {
+    withRequester: true,
+  });
+}

--- a/client/src/components/Badges.tsx
+++ b/client/src/components/Badges.tsx
@@ -1,0 +1,20 @@
+import { Priority, TicketStatus } from "../api/tickets.js";
+
+// ui-spec.md §8 — colour is always redundant with the text (AC-38).
+
+const PRIORITY_LABEL: Record<Priority, string> = {
+  LOW: "Low",
+  MEDIUM: "Medium",
+  HIGH: "High",
+  URGENT: "Urgent",
+};
+
+export function PriorityBadge({ value }: { value: Priority }) {
+  return (
+    <span className={`zg-badge zg-badge-priority-${value.toLowerCase()}`}>{PRIORITY_LABEL[value]}</span>
+  );
+}
+
+export function StatusBadge({ value }: { value: TicketStatus }) {
+  return <span className={`zg-badge zg-badge-status-${value.toLowerCase()}`}>{value === "NEW" ? "New" : value}</span>;
+}

--- a/client/src/pages/MyTickets.tsx
+++ b/client/src/pages/MyTickets.tsx
@@ -1,12 +1,388 @@
-// Implemented in Lab 2 Issue 5 (feature/lab2-5-my-tickets).
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { getCategories, getRelatedSystems, ReferenceItem } from "../api/reference.js";
+import { listTickets, TicketListResponse } from "../api/tickets.js";
+import { PriorityBadge, StatusBadge } from "../components/Badges.js";
+import { useRequester } from "../context/RequesterContext.js";
+
+// My Tickets — docs/lab-02/ui-spec.md §7.3, api-spec.md §3.2.
+
+const PAGE_SIZES = [5, 10, 20, 50];
+
+const SORT_OPTIONS = [
+  { value: "createdAt:desc", label: "Newest first" },
+  { value: "createdAt:asc", label: "Oldest first" },
+  { value: "updatedAt:desc", label: "Recently updated" },
+  { value: "ticketNumber:asc", label: "Ticket number" },
+  { value: "requestedPriority:desc", label: "Priority" },
+];
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+interface Filters {
+  search: string;
+  categoryId: string;
+  relatedSystemId: string;
+  requestedPriority: string;
+  status: string;
+  sort: string;
+  pageSize: number;
+}
+
+const DEFAULT_FILTERS: Filters = {
+  search: "",
+  categoryId: "",
+  relatedSystemId: "",
+  requestedPriority: "",
+  status: "",
+  sort: "createdAt:desc",
+  pageSize: 10,
+};
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleString();
+}
+
 export default function MyTickets() {
+  const { version } = useRequester();
+
+  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [searchInput, setSearchInput] = useState("");
+  const [page, setPage] = useState(1);
+
+  const [state, setState] = useState<"loading" | "ready" | "failed">("loading");
+  const [data, setData] = useState<TicketListResponse | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const [categories, setCategories] = useState<ReferenceItem[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<ReferenceItem[]>([]);
+
+  const filtersApplied = useMemo(
+    () =>
+      filters.search !== "" ||
+      filters.categoryId !== "" ||
+      filters.relatedSystemId !== "" ||
+      filters.requestedPriority !== "" ||
+      filters.status !== "",
+    [filters]
+  );
+
+  useEffect(() => {
+    Promise.all([getCategories(), getRelatedSystems()])
+      .then(([categoryList, systemList]) => {
+        setCategories(categoryList);
+        setRelatedSystems(systemList);
+      })
+      .catch(() => {
+        // Filters degrade to search-only; the list itself reports its own failure.
+      });
+  }, []);
+
+  // Typing should not fire a request per keystroke (ui-spec §7.3).
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFilters((current) => (current.search === searchInput ? current : { ...current, search: searchInput }));
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  // BR-08 — a requester switch reloads the list for the new identity.
+  useEffect(() => {
+    setPage(1);
+  }, [version]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState("loading");
+
+    const [sort, order] = filters.sort.split(":");
+    listTickets({
+      search: filters.search,
+      categoryId: filters.categoryId,
+      relatedSystemId: filters.relatedSystemId,
+      requestedPriority: filters.requestedPriority,
+      status: filters.status,
+      sort,
+      order,
+      page,
+      pageSize: filters.pageSize,
+    })
+      .then((response) => {
+        if (cancelled) return;
+        setData(response);
+        setState("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setState("failed");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filters, page, version, reloadToken]);
+
+  function updateFilter(field: keyof Filters, value: string | number) {
+    setFilters((current) => ({ ...current, [field]: value }));
+    setPage(1);
+  }
+
+  function clearFilters() {
+    setFilters(DEFAULT_FILTERS);
+    setSearchInput("");
+    setPage(1);
+  }
+
+  const items = data?.items ?? [];
+  const showEmpty = state === "ready" && items.length === 0 && !filtersApplied;
+  const showNoResults = state === "ready" && items.length === 0 && filtersApplied;
+  const firstIndex = data && data.totalItems > 0 ? (data.page - 1) * data.pageSize + 1 : 0;
+  const lastIndex = data ? Math.min(data.page * data.pageSize, data.totalItems) : 0;
+
   return (
     <main className="zg-page">
-      <h1 className="zg-page-title">My Tickets</h1>
-      <div className="zg-callout zg-callout-info" role="status">
-        The ticket list arrives with Issue 5. The Development Requester context and navigation are in
-        place.
+      <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <h1 className="zg-page-title mb-0">My Tickets</h1>
+        <Link className="zg-btn zg-btn-primary" to="/tickets/new">
+          Create Ticket
+        </Link>
       </div>
+
+      <section className="zg-card zg-toolbar mb-3" aria-label="Ticket filters">
+        <div className="zg-field">
+          <label className="zg-label" htmlFor="search">
+            Search
+          </label>
+          <input
+            id="search"
+            className="zg-input"
+            type="search"
+            placeholder="Ticket number or summary"
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+          />
+        </div>
+
+        <div className="zg-field">
+          <label className="zg-label" htmlFor="filterCategory">
+            Category
+          </label>
+          <select
+            id="filterCategory"
+            className="zg-select"
+            value={filters.categoryId}
+            onChange={(event) => updateFilter("categoryId", event.target.value)}
+          >
+            <option value="">All categories</option>
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="zg-field">
+          <label className="zg-label" htmlFor="filterSystem">
+            Related System
+          </label>
+          <select
+            id="filterSystem"
+            className="zg-select"
+            value={filters.relatedSystemId}
+            onChange={(event) => updateFilter("relatedSystemId", event.target.value)}
+          >
+            <option value="">All related systems</option>
+            {relatedSystems.map((system) => (
+              <option key={system.id} value={system.id}>
+                {system.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="zg-field">
+          <label className="zg-label" htmlFor="filterPriority">
+            Requested Priority
+          </label>
+          <select
+            id="filterPriority"
+            className="zg-select"
+            value={filters.requestedPriority}
+            onChange={(event) => updateFilter("requestedPriority", event.target.value)}
+          >
+            <option value="">All priorities</option>
+            {["LOW", "MEDIUM", "HIGH", "URGENT"].map((priority) => (
+              <option key={priority} value={priority}>
+                {priority.charAt(0) + priority.slice(1).toLowerCase()}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="zg-field">
+          <label className="zg-label" htmlFor="filterStatus">
+            Status
+          </label>
+          <select
+            id="filterStatus"
+            className="zg-select"
+            value={filters.status}
+            onChange={(event) => updateFilter("status", event.target.value)}
+          >
+            <option value="">All statuses</option>
+            <option value="NEW">New</option>
+          </select>
+        </div>
+
+        <div className="zg-field">
+          <label className="zg-label" htmlFor="sort">
+            Sort by
+          </label>
+          <select
+            id="sort"
+            className="zg-select"
+            value={filters.sort}
+            onChange={(event) => updateFilter("sort", event.target.value)}
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="zg-field">
+          <label className="zg-label" htmlFor="pageSize">
+            Per page
+          </label>
+          <select
+            id="pageSize"
+            className="zg-select"
+            value={filters.pageSize}
+            onChange={(event) => updateFilter("pageSize", Number(event.target.value))}
+          >
+            {PAGE_SIZES.map((size) => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="zg-field zg-toolbar-actions">
+          <button type="button" className="zg-btn zg-btn-secondary" onClick={clearFilters}>
+            Clear filters
+          </button>
+        </div>
+      </section>
+
+      {state === "loading" && (
+        <p role="status" aria-live="polite">
+          Loading tickets…
+        </p>
+      )}
+
+      {state === "failed" && (
+        <div className="zg-callout zg-callout-error" role="alert">
+          <p className="mb-2">Unable to load your tickets.</p>
+          <button type="button" className="zg-btn zg-btn-secondary" onClick={() => setReloadToken((t) => t + 1)}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {showEmpty && (
+        <div className="zg-callout zg-callout-info" role="status">
+          <p className="mb-2">You have not created any tickets yet.</p>
+          <Link className="zg-btn zg-btn-primary" to="/tickets/new">
+            Create Ticket
+          </Link>
+        </div>
+      )}
+
+      {showNoResults && (
+        <div className="zg-callout zg-callout-info" role="status">
+          <p className="mb-2">No tickets match these filters.</p>
+          <button type="button" className="zg-btn zg-btn-secondary" onClick={clearFilters}>
+            Clear filters
+          </button>
+        </div>
+      )}
+
+      {state === "ready" && items.length > 0 && (
+        <>
+          <div className="zg-card p-0">
+            <table className="zg-table">
+              <caption className="visually-hidden">Tickets belonging to the selected Development Requester</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Ticket Number</th>
+                  <th scope="col">Summary</th>
+                  <th scope="col">Category</th>
+                  <th scope="col" className="zg-col-system">
+                    Related System
+                  </th>
+                  <th scope="col">Priority</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Last Updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((ticket) => (
+                  <tr key={ticket.id}>
+                    <td data-label="Ticket Number">
+                      <Link to={`/tickets/${ticket.id}`}>{ticket.ticketNumber}</Link>
+                    </td>
+                    <td data-label="Summary" title={ticket.summary}>
+                      <span className="zg-truncate">{ticket.summary}</span>
+                    </td>
+                    <td data-label="Category">{ticket.category.name}</td>
+                    <td data-label="Related System" className="zg-col-system">
+                      {ticket.relatedSystem.name}
+                    </td>
+                    <td data-label="Priority">
+                      <PriorityBadge value={ticket.requestedPriority} />
+                    </td>
+                    <td data-label="Status">
+                      <StatusBadge value={ticket.status} />
+                    </td>
+                    <td data-label="Last Updated">{formatDate(ticket.updatedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <nav className="zg-pagination" aria-label="Ticket list pages">
+            <p className="zg-muted mb-0">
+              Showing {firstIndex}–{lastIndex} of {data?.totalItems}
+            </p>
+            <div className="d-flex align-items-center gap-2">
+              <button
+                type="button"
+                className="zg-btn zg-btn-secondary"
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+                disabled={(data?.page ?? 1) <= 1}
+              >
+                Previous
+              </button>
+              <span aria-current="page">
+                Page {data?.page} of {data?.totalPages}
+              </span>
+              <button
+                type="button"
+                className="zg-btn zg-btn-secondary"
+                onClick={() => setPage((current) => current + 1)}
+                disabled={(data?.page ?? 1) >= (data?.totalPages ?? 1)}
+              >
+                Next
+              </button>
+            </div>
+          </nav>
+        </>
+      )}
     </main>
   );
 }

--- a/client/src/styles/zen-green.css
+++ b/client/src/styles/zen-green.css
@@ -370,3 +370,133 @@ a:focus-visible {
   color: var(--zg-warning);
   border-color: var(--zg-warning);
 }
+
+/* ---------- toolbar ---------- */
+
+.zg-toolbar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--zg-space-3);
+  align-items: end;
+}
+
+.zg-toolbar .zg-field {
+  margin-bottom: 0;
+}
+
+.zg-toolbar-actions {
+  display: flex;
+  align-items: flex-end;
+}
+
+/* ---------- ticket table ---------- */
+
+.zg-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--zg-surface);
+  border-radius: var(--zg-radius);
+  overflow: hidden;
+}
+
+.zg-table th,
+.zg-table td {
+  padding: var(--zg-space-3) var(--zg-space-4);
+  text-align: left;
+  border-bottom: 1px solid var(--zg-border);
+  vertical-align: middle;
+}
+
+.zg-table th {
+  font-size: 0.875rem;
+  font-weight: 600;
+  background: var(--zg-pale);
+  color: var(--zg-text);
+}
+
+.zg-table tbody tr:hover {
+  background: var(--zg-pale);
+}
+
+.zg-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.zg-table td[data-label="Ticket Number"],
+.zg-table td[data-label="Last Updated"] {
+  white-space: nowrap;
+}
+
+.zg-truncate {
+  display: inline-block;
+  max-width: 32ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
+.zg-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--zg-space-3);
+  margin-top: var(--zg-space-4);
+}
+
+/* Tablet: Related System gives its width to Summary (ui-spec §9). */
+@media (min-width: 768px) and (max-width: 991px) {
+  .zg-col-system {
+    display: none;
+  }
+}
+
+/* Mobile: the same rows become cards — one DOM, no duplicated content. */
+@media (max-width: 767px) {
+  .zg-table thead {
+    display: none;
+  }
+
+  .zg-table,
+  .zg-table tbody,
+  .zg-table tr,
+  .zg-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .zg-table tr {
+    border: 1px solid var(--zg-border);
+    border-radius: var(--zg-radius);
+    margin-bottom: var(--zg-space-3);
+    padding: var(--zg-space-2) var(--zg-space-3);
+    background: var(--zg-surface);
+  }
+
+  .zg-table td {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--zg-space-3);
+    border-bottom: none;
+    padding: var(--zg-space-2) 0;
+  }
+
+  .zg-table td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    color: var(--zg-text-muted);
+    flex: 0 0 auto;
+  }
+
+  .zg-truncate {
+    max-width: 100%;
+    white-space: normal;
+    text-align: right;
+  }
+
+  .zg-table td[data-label="Ticket Number"],
+  .zg-table td[data-label="Last Updated"] {
+    white-space: normal;
+  }
+}

--- a/client/tests/lab-02/AppShell.test.tsx
+++ b/client/tests/lab-02/AppShell.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import * as reference from "../../src/api/reference.js";
@@ -41,8 +41,9 @@ describe("application shell", () => {
     renderApp("/tickets");
 
     expect(await screen.findByText("Napat Srisai")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /my tickets/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /create ticket/i })).toBeInTheDocument();
+    const nav = screen.getByRole("navigation", { name: /main/i });
+    expect(within(nav).getByRole("link", { name: /my tickets/i })).toBeInTheDocument();
+    expect(within(nav).getByRole("link", { name: /create ticket/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /change requester/i })).toBeInTheDocument();
   });
 
@@ -52,11 +53,12 @@ describe("application shell", () => {
 
     renderApp("/tickets/new");
 
-    const createLink = await screen.findByRole("link", { name: /create ticket/i });
+    const nav = await screen.findByRole("navigation", { name: /main/i });
+    const createLink = within(nav).getByRole("link", { name: /create ticket/i });
     expect(createLink).toHaveAttribute("aria-current", "page");
     expect(createLink.className).toContain("zg-nav-link-active");
 
-    const listLink = screen.getByRole("link", { name: /my tickets/i });
+    const listLink = within(nav).getByRole("link", { name: /my tickets/i });
     expect(listLink).not.toHaveAttribute("aria-current");
   });
 
@@ -70,7 +72,7 @@ describe("application shell", () => {
 
     expect(await screen.findByText(/this is not a login screen/i)).toBeInTheDocument();
     expect(window.localStorage.getItem(REQUESTER_STORAGE_KEY)).toBeNull();
-    expect(screen.queryByRole("link", { name: /my tickets/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("navigation", { name: /main/i })).not.toBeInTheDocument();
   });
 
   // UI-03 / AC-04 — the new identity is the one the shell reports

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import * as reference from "../../src/api/reference.js";
+import * as ticketsApi from "../../src/api/tickets.js";
+import { REQUESTER_STORAGE_KEY } from "../../src/api/client.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import MyTickets from "../../src/pages/MyTickets.js";
+
+// UI-10 … UI-14 — docs/lab-02/tests.md §2.3
+
+const REQUESTERS = [
+  { id: 1, name: "Napat Srisai", email: "napat.sri@kmutt.ac.th", department: "Faculty of Engineering" },
+];
+const CATEGORIES = [
+  { id: 1, name: "Account and Access" },
+  { id: 2, name: "Hardware" },
+];
+const RELATED_SYSTEMS = [{ id: 7, name: "Corporate Laptop" }];
+
+function item(overrides: Partial<ticketsApi.TicketListItem> = {}): ticketsApi.TicketListItem {
+  return {
+    id: 42,
+    ticketNumber: "TKT-2026-000042",
+    summary: "Laptop battery drains fast",
+    category: { id: 2, name: "Hardware" },
+    relatedSystem: { id: 7, name: "Corporate Laptop" },
+    requestedPriority: "HIGH",
+    status: "NEW",
+    attachmentCount: 0,
+    createdAt: "2026-08-12T04:11:20.310Z",
+    updatedAt: "2026-08-12T04:11:20.310Z",
+    ...overrides,
+  };
+}
+
+function page(
+  items: ticketsApi.TicketListItem[],
+  overrides: Partial<ticketsApi.TicketListResponse> = {}
+): ticketsApi.TicketListResponse {
+  return {
+    items,
+    page: 1,
+    pageSize: 10,
+    totalItems: items.length,
+    totalPages: 1,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+  vi.spyOn(reference, "getRequesters").mockResolvedValue(REQUESTERS);
+  vi.spyOn(reference, "getCategories").mockResolvedValue(CATEGORIES);
+  vi.spyOn(reference, "getRelatedSystems").mockResolvedValue(RELATED_SYSTEMS);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderMyTickets() {
+  return render(
+    <MemoryRouter initialEntries={["/tickets"]}>
+      <RequesterProvider>
+        <Routes>
+          <Route path="/tickets" element={<MyTickets />} />
+          <Route path="/tickets/new" element={<h1>Create Ticket</h1>} />
+        </Routes>
+      </RequesterProvider>
+    </MemoryRouter>
+  );
+}
+
+/** The last query the page sent to the API. */
+function lastQuery(spy: { mock: { calls: unknown[][] } }): ticketsApi.TicketListParams {
+  const calls = spy.mock.calls;
+  return calls[calls.length - 1][0] as ticketsApi.TicketListParams;
+}
+
+describe("My Tickets", () => {
+  // UI-10 / AC-16
+  it("renders the tickets and the pagination metadata from the API", async () => {
+    vi.spyOn(ticketsApi, "listTickets").mockResolvedValue(
+      page([item(), item({ id: 43, ticketNumber: "TKT-2026-000043", summary: "VPN drops every hour" })], {
+        totalItems: 2,
+      })
+    );
+
+    renderMyTickets();
+
+    const table = await screen.findByRole("table");
+    expect(within(table).getByText("TKT-2026-000042")).toBeInTheDocument();
+    expect(within(table).getByText("VPN drops every hour")).toBeInTheDocument();
+    expect(screen.getByText(/showing 1–2 of 2/i)).toBeInTheDocument();
+  });
+
+  // UI-11 / AC-17
+  it("sends a search parameter after typing, without a request per keystroke", async () => {
+    const spy = vi.spyOn(ticketsApi, "listTickets").mockResolvedValue(page([item()]));
+
+    renderMyTickets();
+    await screen.findByRole("table");
+    const callsBefore = spy.mock.calls.length;
+
+    await userEvent.type(screen.getByLabelText(/^Search/), "laptop");
+
+    await waitFor(() => expect(lastQuery(spy).search).toBe("laptop"));
+    expect(spy.mock.calls.length - callsBefore).toBeLessThan(6);
+  });
+
+  // UI-11 / AC-18
+  it("sends the documented filter parameters", async () => {
+    const spy = vi.spyOn(ticketsApi, "listTickets").mockResolvedValue(page([item()]));
+
+    renderMyTickets();
+    await screen.findByRole("table");
+
+    await userEvent.selectOptions(screen.getByLabelText(/^Category/), "2");
+    await waitFor(() => expect(lastQuery(spy).categoryId).toBe("2"));
+
+    await userEvent.selectOptions(screen.getByLabelText(/^Requested Priority/), "HIGH");
+    await waitFor(() => expect(lastQuery(spy).requestedPriority).toBe("HIGH"));
+    expect(lastQuery(spy).categoryId).toBe("2");
+    expect(lastQuery(spy).page).toBe(1);
+  });
+
+  // UI-12 / AC-19, AC-20
+  it("sends sort, page size, and page changes", async () => {
+    const spy = vi
+      .spyOn(ticketsApi, "listTickets")
+      .mockResolvedValue(page([item()], { totalItems: 12, totalPages: 3 }));
+
+    renderMyTickets();
+    await screen.findByRole("table");
+
+    await userEvent.selectOptions(screen.getByLabelText(/^Sort by/), "createdAt:asc");
+    await waitFor(() => expect(lastQuery(spy)).toMatchObject({ sort: "createdAt", order: "asc" }));
+
+    await userEvent.selectOptions(screen.getByLabelText(/^Per page/), "20");
+    await waitFor(() => expect(lastQuery(spy).pageSize).toBe(20));
+
+    await userEvent.click(screen.getByRole("button", { name: /next/i }));
+    await waitFor(() => expect(lastQuery(spy).page).toBe(2));
+  });
+
+  it("disables Previous on the first page and Next on the last page", async () => {
+    vi.spyOn(ticketsApi, "listTickets").mockResolvedValue(page([item()], { totalItems: 1, totalPages: 1 }));
+
+    renderMyTickets();
+    await screen.findByRole("table");
+
+    expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+  });
+
+  // UI-13 / AC-22
+  it("shows the empty state when the requester has no tickets at all", async () => {
+    vi.spyOn(ticketsApi, "listTickets").mockResolvedValue(page([]));
+
+    renderMyTickets();
+
+    expect(await screen.findByText(/you have not created any tickets yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no tickets match these filters/i)).not.toBeInTheDocument();
+  });
+
+  // UI-13 / AC-23, BR-30
+  it("shows the no-results state with Clear filters when filters match nothing", async () => {
+    const spy = vi.spyOn(ticketsApi, "listTickets").mockResolvedValue(page([]));
+
+    renderMyTickets();
+    await screen.findByText(/you have not created any tickets yet/i);
+
+    await userEvent.selectOptions(screen.getByLabelText(/^Category/), "2");
+
+    expect(await screen.findByText(/no tickets match these filters/i)).toBeInTheDocument();
+    expect(screen.queryByText(/you have not created any tickets yet/i)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByRole("button", { name: /clear filters/i })[0]);
+    await waitFor(() => expect(lastQuery(spy).categoryId).toBe(""));
+    expect(await screen.findByText(/you have not created any tickets yet/i)).toBeInTheDocument();
+  });
+
+  // UI-14 / AC-24
+  it("shows a safe failure state with Retry when the list cannot be loaded", async () => {
+    const spy = vi.spyOn(ticketsApi, "listTickets").mockRejectedValueOnce(new Error("down"));
+    spy.mockResolvedValue(page([item()]));
+
+    renderMyTickets();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/unable to load your tickets/i);
+
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+  });
+
+  it("links each ticket number to its detail screen", async () => {
+    vi.spyOn(ticketsApi, "listTickets").mockResolvedValue(page([item()]));
+
+    renderMyTickets();
+
+    const link = await screen.findByRole("link", { name: "TKT-2026-000042" });
+    expect(link).toHaveAttribute("href", "/tickets/42");
+  });
+});

--- a/client/tests/lab-02/zen-green.style.test.tsx
+++ b/client/tests/lab-02/zen-green.style.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import * as reference from "../../src/api/reference.js";
+import * as ticketsApi from "../../src/api/tickets.js";
+import { REQUESTER_STORAGE_KEY } from "../../src/api/client.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import CreateTicket from "../../src/pages/CreateTicket.js";
+import MyTickets from "../../src/pages/MyTickets.js";
+
+// STYLE-01 … STYLE-05 — docs/lab-02/tests.md §2.4, ui-spec.md §3–§8
+
+const REQUESTERS = [
+  { id: 1, name: "Napat Srisai", email: "napat.sri@kmutt.ac.th", department: "Faculty of Engineering" },
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+  vi.spyOn(reference, "getRequesters").mockResolvedValue(REQUESTERS);
+  vi.spyOn(reference, "getCategories").mockResolvedValue([{ id: 2, name: "Hardware" }]);
+  vi.spyOn(reference, "getRelatedSystems").mockResolvedValue([{ id: 7, name: "Corporate Laptop" }]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderCreateTicket() {
+  return render(
+    <MemoryRouter>
+      <RequesterProvider>
+        <CreateTicket />
+      </RequesterProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("Zen Green form styling", () => {
+  // STYLE-01 / AC-36
+  it("styles read-only fields differently from editable fields", async () => {
+    renderCreateTicket();
+
+    const ticketNumber = await screen.findByLabelText(/Ticket Number/);
+    expect(ticketNumber.className).toContain("zg-readonly");
+    expect(ticketNumber).toHaveAttribute("aria-readonly", "true");
+
+    const summary = screen.getByLabelText(/^Summary/);
+    expect(summary.className).toContain("zg-input");
+    expect(summary.className).not.toContain("zg-readonly");
+    expect(summary).not.toHaveAttribute("readonly");
+  });
+
+  // STYLE-02 / AC-37, ui-spec §4
+  it("marks required fields with an asterisk and still shows a message below the field", async () => {
+    renderCreateTicket();
+
+    const summaryLabel = (await screen.findByText(/^Summary/)).closest("label")!;
+    const asterisk = within(summaryLabel).getByText("*");
+    expect(asterisk).toHaveAttribute("aria-hidden", "true");
+    expect(asterisk.className).toContain("zg-required");
+
+    await userEvent.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    const message = screen.getByText("Summary is required");
+    expect(message.className).toContain("zg-message-error");
+    expect(message).toHaveAttribute("id", "summary-error");
+
+    const summary = screen.getByLabelText(/^Summary/);
+    expect(summary).toHaveAttribute("aria-describedby", "summary-error");
+    expect(summary.className).toContain("zg-invalid");
+  });
+
+  // STYLE-03 / ui-spec §5
+  it("uses the documented button hierarchy and disables the busy submit", async () => {
+    let resolve!: (ticket: ticketsApi.Ticket) => void;
+    vi.spyOn(ticketsApi, "createTicket").mockReturnValue(
+      new Promise<ticketsApi.Ticket>((r) => (resolve = r))
+    );
+
+    renderCreateTicket();
+
+    const submit = await screen.findByRole("button", { name: /submit ticket/i });
+    expect(submit.className).toContain("zg-btn-primary");
+    expect(screen.getByRole("link", { name: /cancel/i }).className).toContain("zg-btn-secondary");
+
+    await userEvent.selectOptions(screen.getByLabelText(/^Category/), "2");
+    await userEvent.selectOptions(screen.getByLabelText(/^Related System/), "7");
+    await userEvent.selectOptions(screen.getByLabelText(/^Requested Priority/), "MEDIUM");
+    await userEvent.type(screen.getByLabelText(/^Summary/), "Laptop battery drains fast");
+    await userEvent.type(
+      screen.getByLabelText(/^Description/),
+      "The laptop discharges from full to empty within an hour even when idle."
+    );
+    await userEvent.click(submit);
+
+    const busy = screen.getByRole("button", { name: /submitting/i });
+    expect(busy).toBeDisabled();
+
+    resolve({
+      id: 1,
+      ticketNumber: "TKT-2026-000001",
+      status: "NEW",
+      requestedPriority: "MEDIUM",
+      summary: "Laptop battery drains fast",
+      description: "…",
+      requester: { id: 1, name: "Napat Srisai" },
+      category: { id: 2, name: "Hardware" },
+      relatedSystem: { id: 7, name: "Corporate Laptop" },
+      createdAt: "2026-08-12T04:11:20.310Z",
+      updatedAt: "2026-08-12T04:11:20.310Z",
+      attachments: [],
+    });
+    expect(await screen.findByText("TKT-2026-000001")).toBeInTheDocument();
+  });
+});
+
+describe("Zen Green badges and accessibility hooks", () => {
+  // STYLE-04 / AC-38
+  it("conveys priority and status as text, not colour alone", async () => {
+    vi.spyOn(ticketsApi, "listTickets").mockResolvedValue({
+      items: [
+        {
+          id: 42,
+          ticketNumber: "TKT-2026-000042",
+          summary: "Laptop battery drains fast",
+          category: { id: 2, name: "Hardware" },
+          relatedSystem: { id: 7, name: "Corporate Laptop" },
+          requestedPriority: "URGENT",
+          status: "NEW",
+          attachmentCount: 0,
+          createdAt: "2026-08-12T04:11:20.310Z",
+          updatedAt: "2026-08-12T04:11:20.310Z",
+        },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalItems: 1,
+      totalPages: 1,
+    });
+
+    render(
+      <MemoryRouter>
+        <RequesterProvider>
+          <MyTickets />
+        </RequesterProvider>
+      </MemoryRouter>
+    );
+
+    const table = await screen.findByRole("table");
+    const priority = within(table).getByText("Urgent");
+    const status = within(table).getByText("New");
+
+    expect(priority.className).toContain("zg-badge-priority-urgent");
+    expect(status.className).toContain("zg-badge-status-new");
+    expect(priority.textContent?.trim()).toBe("Urgent");
+    expect(status.textContent?.trim()).toBe("New");
+  });
+
+  // STYLE-05 / AC-39, AC-40
+  it("labels every control and marks invalid fields for assistive technology", async () => {
+    renderCreateTicket();
+
+    for (const label of [/^Category/, /^Related System/, /^Requested Priority/, /^Summary/, /^Description/]) {
+      expect(await screen.findByLabelText(label)).toBeInTheDocument();
+    }
+
+    await userEvent.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    const category = screen.getByLabelText(/^Category/);
+    expect(category).toHaveAttribute("aria-invalid", "true");
+    expect(category).toHaveAttribute("aria-describedby", "categoryId-error");
+    expect(category).toHaveAttribute("aria-required", "true");
+  });
+});

--- a/server/src/lib/query.ts
+++ b/server/src/lib/query.ts
@@ -1,0 +1,157 @@
+import { PRIORITIES, PriorityValue, FieldError } from "./validation.js";
+
+// Ticket-list query contract — docs/lab-02/api-spec.md §3.2 (BR-21 … BR-27).
+// Unknown or malformed parameters are rejected, never silently ignored (BR-25).
+
+export const SORT_FIELDS = ["createdAt", "updatedAt", "ticketNumber", "requestedPriority"] as const;
+export type SortField = (typeof SORT_FIELDS)[number];
+
+export const ORDERS = ["asc", "desc"] as const;
+export type SortOrder = (typeof ORDERS)[number];
+
+export const STATUSES = ["NEW"] as const;
+export type StatusValue = (typeof STATUSES)[number];
+
+export const PAGE_SIZES = [5, 10, 20, 50] as const;
+export const DEFAULT_PAGE_SIZE = 10;
+export const SEARCH_MAX = 120;
+
+const ALLOWED_PARAMS = new Set([
+  "search",
+  "categoryId",
+  "relatedSystemId",
+  "requestedPriority",
+  "status",
+  "sort",
+  "order",
+  "page",
+  "pageSize",
+]);
+
+export interface TicketListQuery {
+  search?: string;
+  categoryId?: number;
+  relatedSystemId?: number;
+  requestedPriority?: PriorityValue;
+  status?: StatusValue;
+  sort: SortField;
+  order: SortOrder;
+  page: number;
+  pageSize: number;
+}
+
+export interface QueryParseResult {
+  errors: FieldError[];
+  value?: TicketListQuery;
+}
+
+function firstValue(raw: unknown): string | undefined {
+  if (raw === undefined) return undefined;
+  if (Array.isArray(raw)) return typeof raw[0] === "string" ? raw[0] : undefined;
+  return typeof raw === "string" ? raw : undefined;
+}
+
+function parsePositiveInt(raw: string): number | null {
+  if (!/^\d+$/.test(raw)) return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value > 0 ? value : null;
+}
+
+export function parseTicketListQuery(query: Record<string, unknown>): QueryParseResult {
+  const errors: FieldError[] = [];
+
+  for (const name of Object.keys(query)) {
+    if (!ALLOWED_PARAMS.has(name)) {
+      errors.push({ field: name, message: `Unknown query parameter "${name}"` });
+    }
+  }
+
+  const result: TicketListQuery = {
+    sort: "createdAt",
+    order: "desc",
+    page: 1,
+    pageSize: DEFAULT_PAGE_SIZE,
+  };
+
+  const search = firstValue(query.search);
+  if (search !== undefined) {
+    const trimmed = search.trim();
+    if (trimmed.length > SEARCH_MAX) {
+      errors.push({ field: "search", message: `search must be ${SEARCH_MAX} characters or fewer` });
+    } else if (trimmed !== "") {
+      result.search = trimmed;
+    }
+  }
+
+  for (const field of ["categoryId", "relatedSystemId"] as const) {
+    const raw = firstValue(query[field]);
+    if (raw === undefined || raw === "") continue;
+    const id = parsePositiveInt(raw);
+    if (id === null) {
+      errors.push({ field, message: `${field} must be a positive integer` });
+    } else {
+      result[field] = id;
+    }
+  }
+
+  const priority = firstValue(query.requestedPriority);
+  if (priority !== undefined && priority !== "") {
+    if (!PRIORITIES.includes(priority as PriorityValue)) {
+      errors.push({
+        field: "requestedPriority",
+        message: `requestedPriority must be one of ${PRIORITIES.join(", ")}`,
+      });
+    } else {
+      result.requestedPriority = priority as PriorityValue;
+    }
+  }
+
+  const status = firstValue(query.status);
+  if (status !== undefined && status !== "") {
+    if (!STATUSES.includes(status as StatusValue)) {
+      errors.push({ field: "status", message: `status must be one of ${STATUSES.join(", ")}` });
+    } else {
+      result.status = status as StatusValue;
+    }
+  }
+
+  const sort = firstValue(query.sort);
+  if (sort !== undefined && sort !== "") {
+    if (!SORT_FIELDS.includes(sort as SortField)) {
+      errors.push({ field: "sort", message: `sort must be one of ${SORT_FIELDS.join(", ")}` });
+    } else {
+      result.sort = sort as SortField;
+    }
+  }
+
+  const order = firstValue(query.order);
+  if (order !== undefined && order !== "") {
+    if (!ORDERS.includes(order as SortOrder)) {
+      errors.push({ field: "order", message: `order must be one of ${ORDERS.join(", ")}` });
+    } else {
+      result.order = order as SortOrder;
+    }
+  }
+
+  const page = firstValue(query.page);
+  if (page !== undefined && page !== "") {
+    const parsed = parsePositiveInt(page);
+    if (parsed === null) {
+      errors.push({ field: "page", message: "page must be a positive integer" });
+    } else {
+      result.page = parsed;
+    }
+  }
+
+  const pageSize = firstValue(query.pageSize);
+  if (pageSize !== undefined && pageSize !== "") {
+    const parsed = parsePositiveInt(pageSize);
+    if (parsed === null || !PAGE_SIZES.includes(parsed as (typeof PAGE_SIZES)[number])) {
+      errors.push({ field: "pageSize", message: `pageSize must be one of ${PAGE_SIZES.join(", ")}` });
+    } else {
+      result.pageSize = parsed;
+    }
+  }
+
+  return errors.length > 0 ? { errors } : { errors, value: result };
+}

--- a/server/src/routes/tickets.ts
+++ b/server/src/routes/tickets.ts
@@ -4,6 +4,7 @@ import { getPrisma } from "../prisma.js";
 import { resolveRequester, RequesterError } from "../lib/requester.js";
 import { validateCreateTicket } from "../lib/validation.js";
 import { formatTicketNumber } from "../lib/ticket-number.js";
+import { parseTicketListQuery } from "../lib/query.js";
 
 // Ticket routes — contract: docs/lab-02/api-spec.md §3.
 
@@ -121,5 +122,81 @@ ticketsRouter.post("/api/tickets", async (req: Request, res: Response) => {
     res.status(201).json({ ...ticket, attachments: [] });
   } catch {
     res.status(500).json({ error: "Unable to create the ticket" });
+  }
+});
+
+ticketsRouter.get("/api/tickets", async (req: Request, res: Response) => {
+  const prisma = getPrisma();
+
+  let requesterId: number;
+  try {
+    requesterId = (await resolveRequester(req)).id;
+  } catch (error) {
+    if (handleRequesterError(error, res)) return;
+    res.status(500).json({ error: "Unable to load tickets" });
+    return;
+  }
+
+  const { errors, value: query } = parseTicketListQuery(req.query as Record<string, unknown>);
+  if (!query) {
+    res.status(400).json({ error: "Invalid query parameters", fields: errors });
+    return;
+  }
+
+  // BR-14 — ownership is applied server-side; no query parameter can widen it.
+  const where = {
+    requesterId,
+    ...(query.categoryId ? { categoryId: query.categoryId } : {}),
+    ...(query.relatedSystemId ? { relatedSystemId: query.relatedSystemId } : {}),
+    ...(query.requestedPriority ? { requestedPriority: query.requestedPriority } : {}),
+    ...(query.status ? { status: query.status } : {}),
+    ...(query.search
+      ? {
+          OR: [
+            { ticketNumber: { contains: query.search, mode: "insensitive" as const } },
+            { summary: { contains: query.search, mode: "insensitive" as const } },
+          ],
+        }
+      : {}),
+  };
+
+  try {
+    const [totalItems, tickets] = await Promise.all([
+      prisma.ticket.count({ where }),
+      prisma.ticket.findMany({
+        where,
+        // BR-23 — the requested sort, then id desc so ties are deterministic.
+        orderBy: [{ [query.sort]: query.order }, { id: "desc" }],
+        skip: (query.page - 1) * query.pageSize,
+        take: query.pageSize,
+        select: {
+          id: true,
+          ticketNumber: true,
+          summary: true,
+          requestedPriority: true,
+          status: true,
+          createdAt: true,
+          updatedAt: true,
+          category: { select: { id: true, name: true } },
+          relatedSystem: { select: { id: true, name: true } },
+          // Active attachments only (BR-33, BR-39).
+          attachments: { where: { removedAt: null }, select: { id: true } },
+        },
+      }),
+    ]);
+
+    res.status(200).json({
+      items: tickets.map(({ attachments, ...ticket }) => ({
+        ...ticket,
+        attachmentCount: attachments.length,
+      })),
+      page: query.page,
+      pageSize: query.pageSize,
+      totalItems,
+      // BR-27 — a page past the end is an empty page, not an error.
+      totalPages: Math.max(1, Math.ceil(totalItems / query.pageSize)),
+    });
+  } catch {
+    res.status(500).json({ error: "Unable to load tickets" });
   }
 });

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { formatTicketNumber } from "../../src/lib/ticket-number.js";
+
+// API-07 … API-14 — docs/lab-02/tests.md §2.2
+// Requires a migrated, seeded database.
+
+const prisma = getPrisma();
+
+let ownerId = 0;
+let otherId = 0;
+let emptyRequesterId = 0;
+let categoryA = 0;
+let categoryB = 0;
+let relatedSystemId = 0;
+
+const MARK = `lab2list${Date.now()}`;
+const createdIds: number[] = [];
+
+async function makeTicket(options: {
+  requesterId: number;
+  summary: string;
+  categoryId?: number;
+  priority?: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+  createdAt?: Date;
+}) {
+  const draft = await prisma.ticket.create({
+    data: {
+      ticketNumber: `PENDING-${MARK}-${options.summary}`,
+      requesterId: options.requesterId,
+      categoryId: options.categoryId ?? categoryA,
+      relatedSystemId,
+      summary: options.summary,
+      description: `Seeded by the my-tickets API test suite (${MARK}).`,
+      requestedPriority: options.priority ?? "MEDIUM",
+      ...(options.createdAt ? { createdAt: options.createdAt } : {}),
+    },
+    select: { id: true, createdAt: true },
+  });
+
+  const ticket = await prisma.ticket.update({
+    where: { id: draft.id },
+    data: { ticketNumber: formatTicketNumber(draft.createdAt.getFullYear(), draft.id) },
+    select: { id: true, ticketNumber: true },
+  });
+
+  createdIds.push(ticket.id);
+  return ticket;
+}
+
+function list(query: string, requesterId: number | null = ownerId) {
+  const req = request(app).get(`/api/tickets${query}`);
+  if (requesterId !== null) req.set("X-Requester-Id", String(requesterId));
+  return req;
+}
+
+beforeAll(async () => {
+  const requesters = await prisma.requesterUser.findMany({
+    where: { isActive: true },
+    orderBy: { id: "asc" },
+    take: 3,
+  });
+  const categories = await prisma.category.findMany({ where: { isActive: true }, orderBy: { id: "asc" }, take: 2 });
+  const relatedSystem = await prisma.relatedSystem.findFirst({ where: { isActive: true }, orderBy: { id: "asc" } });
+
+  ownerId = requesters[0].id;
+  otherId = requesters[1].id;
+  emptyRequesterId = requesters[2].id;
+  categoryA = categories[0].id;
+  categoryB = categories[1].id;
+  relatedSystemId = relatedSystem!.id;
+
+  // The owner keeps a clean slate so counts in this suite are exact.
+  await prisma.ticket.deleteMany({ where: { requesterId: { in: [ownerId, emptyRequesterId] } } });
+
+  const base = new Date("2026-03-01T00:00:00.000Z");
+  for (let i = 0; i < 12; i++) {
+    await makeTicket({
+      requesterId: ownerId,
+      summary: `${MARK} owner ticket ${String(i).padStart(2, "0")}`,
+      categoryId: i % 2 === 0 ? categoryA : categoryB,
+      priority: i % 3 === 0 ? "HIGH" : "LOW",
+      createdAt: new Date(base.getTime() + i * 60_000),
+    });
+  }
+
+  await makeTicket({ requesterId: ownerId, summary: `${MARK} printer keeps jamming badly` });
+  await makeTicket({ requesterId: otherId, summary: `${MARK} other requester ticket` });
+});
+
+afterAll(async () => {
+  await prisma.ticket.deleteMany({ where: { id: { in: createdIds } } });
+});
+
+describe("GET /api/tickets", () => {
+  // API-07 / AC-16, BR-14, BR-26
+  it("returns only the selected requester's tickets with pagination metadata", async () => {
+    const res = await list("?pageSize=50");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ page: 1, pageSize: 50 });
+    expect(res.body.totalItems).toBe(13);
+    expect(res.body.items).toHaveLength(13);
+    expect(res.body.items.every((t: { summary: string }) => t.summary.includes(MARK))).toBe(true);
+    expect(
+      res.body.items.some((t: { summary: string }) => t.summary.includes("other requester"))
+    ).toBe(false);
+    expect(res.body.items[0]).toHaveProperty("attachmentCount", 0);
+  });
+
+  it("never returns another requester's ticket even when both exist", async () => {
+    const mine = await list("?pageSize=50");
+    const theirs = await list("?pageSize=50", otherId);
+
+    const myIds = mine.body.items.map((t: { id: number }) => t.id);
+    const theirIds = theirs.body.items.map((t: { id: number }) => t.id);
+
+    expect(myIds.some((id: number) => theirIds.includes(id))).toBe(false);
+  });
+
+  // API-08 / AC-17, BR-21
+  it("searches summary and ticket number case-insensitively", async () => {
+    const bySummary = await list("?search=PRINTER%20KEEPS");
+    expect(bySummary.status).toBe(200);
+    expect(bySummary.body.totalItems).toBe(1);
+    expect(bySummary.body.items[0].summary).toMatch(/printer keeps jamming/i);
+
+    const number = bySummary.body.items[0].ticketNumber as string;
+    const byNumber = await list(`?search=${number.toLowerCase()}`);
+    expect(byNumber.body.totalItems).toBe(1);
+    expect(byNumber.body.items[0].ticketNumber).toBe(number);
+  });
+
+  // API-09 / AC-18, BR-22
+  it("filters by category, priority, and status, and combines filters with AND", async () => {
+    const byCategory = await list(`?categoryId=${categoryB}&pageSize=50`);
+    expect(byCategory.body.items.every((t: { category: { id: number } }) => t.category.id === categoryB)).toBe(true);
+    expect(byCategory.body.totalItems).toBe(6);
+
+    const byPriority = await list("?requestedPriority=HIGH&pageSize=50");
+    expect(byPriority.body.items.every((t: { requestedPriority: string }) => t.requestedPriority === "HIGH")).toBe(true);
+
+    const byStatus = await list("?status=NEW&pageSize=50");
+    expect(byStatus.body.totalItems).toBe(13);
+
+    const combined = await list(`?categoryId=${categoryB}&requestedPriority=HIGH&pageSize=50`);
+    expect(combined.body.totalItems).toBeLessThan(byCategory.body.totalItems);
+    expect(
+      combined.body.items.every(
+        (t: { category: { id: number }; requestedPriority: string }) =>
+          t.category.id === categoryB && t.requestedPriority === "HIGH"
+      )
+    ).toBe(true);
+  });
+
+  // API-10 / AC-19, BR-23
+  it("sorts by the requested field and direction, newest first by default", async () => {
+    const defaultOrder = await list("?pageSize=50");
+    const dates = defaultOrder.body.items.map((t: { createdAt: string }) => new Date(t.createdAt).getTime());
+    expect([...dates].sort((a, b) => b - a)).toEqual(dates);
+
+    const ascending = await list("?sort=createdAt&order=asc&pageSize=50");
+    const ascDates = ascending.body.items.map((t: { createdAt: string }) => new Date(t.createdAt).getTime());
+    expect([...ascDates].sort((a, b) => a - b)).toEqual(ascDates);
+    expect(ascending.body.items[0].id).not.toBe(defaultOrder.body.items[0].id);
+
+    const byNumber = await list("?sort=ticketNumber&order=asc&pageSize=50");
+    const numbers = byNumber.body.items.map((t: { ticketNumber: string }) => t.ticketNumber);
+    expect([...numbers].sort()).toEqual(numbers);
+  });
+
+  // API-11 / AC-20, BR-24
+  it("pages through the result set without repeating items", async () => {
+    const first = await list("?page=1&pageSize=5");
+    const second = await list("?page=2&pageSize=5");
+
+    expect(first.body.items).toHaveLength(5);
+    expect(second.body.items).toHaveLength(5);
+    expect(first.body.totalPages).toBe(3);
+    expect(second.body.page).toBe(2);
+
+    const firstIds = first.body.items.map((t: { id: number }) => t.id);
+    const secondIds = second.body.items.map((t: { id: number }) => t.id);
+    expect(firstIds.some((id: number) => secondIds.includes(id))).toBe(false);
+  });
+
+  // API-12 / AC-21, BR-25
+  it("rejects an invalid page size and an unknown parameter with 400", async () => {
+    const badSize = await list("?pageSize=7");
+    expect(badSize.status).toBe(400);
+    expect(badSize.body.fields[0].field).toBe("pageSize");
+
+    const unknown = await list("?pagesize=10");
+    expect(unknown.status).toBe(400);
+    expect(unknown.body.fields[0].field).toBe("pagesize");
+  });
+
+  // API-13 / BR-27
+  it("returns an empty page with correct metadata past the last page", async () => {
+    const res = await list("?page=99&pageSize=5");
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.totalItems).toBe(13);
+    expect(res.body.page).toBe(99);
+  });
+
+  // API-14 / AC-22
+  it("returns an empty result set for a requester with no tickets", async () => {
+    const res = await list("", emptyRequesterId);
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.totalItems).toBe(0);
+    expect(res.body.totalPages).toBe(1);
+  });
+
+  it("requires a Development Requester header", async () => {
+    const res = await list("", null);
+
+    expect(res.status).toBe(400);
+    expect(res.body.field).toBe("X-Requester-Id");
+  });
+});

--- a/server/tests/lab-02/query.unit.test.ts
+++ b/server/tests/lab-02/query.unit.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { parseTicketListQuery, DEFAULT_PAGE_SIZE } from "../../src/lib/query.js";
+
+// UNIT-05 — docs/lab-02/tests.md §2.1 (BR-24, BR-25)
+
+describe("ticket list query parsing", () => {
+  it("applies the documented defaults when nothing is supplied", () => {
+    const { errors, value } = parseTicketListQuery({});
+
+    expect(errors).toEqual([]);
+    expect(value).toEqual({ sort: "createdAt", order: "desc", page: 1, pageSize: DEFAULT_PAGE_SIZE });
+  });
+
+  it("accepts every permitted page size and rejects the rest", () => {
+    for (const size of ["5", "10", "20", "50"]) {
+      expect(parseTicketListQuery({ pageSize: size }).value?.pageSize).toBe(Number(size));
+    }
+
+    const rejected = parseTicketListQuery({ pageSize: "7" });
+    expect(rejected.value).toBeUndefined();
+    expect(rejected.errors[0].field).toBe("pageSize");
+  });
+
+  it("rejects an unknown query parameter instead of ignoring it", () => {
+    const { errors, value } = parseTicketListQuery({ pagesize: "50" });
+
+    expect(value).toBeUndefined();
+    expect(errors[0].field).toBe("pagesize");
+    expect(errors[0].message).toMatch(/unknown query parameter/i);
+  });
+
+  it("rejects malformed numbers and unknown enum values", () => {
+    expect(parseTicketListQuery({ page: "0" }).errors[0].field).toBe("page");
+    expect(parseTicketListQuery({ page: "abc" }).errors[0].field).toBe("page");
+    expect(parseTicketListQuery({ categoryId: "-2" }).errors[0].field).toBe("categoryId");
+    expect(parseTicketListQuery({ requestedPriority: "CRITICAL" }).errors[0].field).toBe("requestedPriority");
+    expect(parseTicketListQuery({ sort: "summary" }).errors[0].field).toBe("sort");
+    expect(parseTicketListQuery({ order: "sideways" }).errors[0].field).toBe("order");
+    expect(parseTicketListQuery({ status: "CLOSED" }).errors[0].field).toBe("status");
+  });
+
+  it("keeps valid filters, trims search, and ignores empty values", () => {
+    const { value } = parseTicketListQuery({
+      search: "  laptop  ",
+      categoryId: "2",
+      relatedSystemId: "7",
+      requestedPriority: "HIGH",
+      status: "NEW",
+      sort: "updatedAt",
+      order: "asc",
+      page: "3",
+      pageSize: "20",
+    });
+
+    expect(value).toEqual({
+      search: "laptop",
+      categoryId: 2,
+      relatedSystemId: 7,
+      requestedPriority: "HIGH",
+      status: "NEW",
+      sort: "updatedAt",
+      order: "asc",
+      page: 3,
+      pageSize: 20,
+    });
+
+    expect(parseTicketListQuery({ search: "   ", categoryId: "" }).value).toEqual({
+      sort: "createdAt",
+      order: "desc",
+      page: 1,
+      pageSize: DEFAULT_PAGE_SIZE,
+    });
+  });
+
+  it("rejects a search term longer than the documented limit", () => {
+    expect(parseTicketListQuery({ search: "a".repeat(121) }).errors[0].field).toBe("search");
+    expect(parseTicketListQuery({ search: "a".repeat(120) }).errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements api-spec.md §3.2 and ui-spec.md §7.3.

**Backend** — `GET /api/tickets`
- `lib/query.ts` parses the whole documented query contract and rejects unknown or malformed parameters with 400 naming the offender, rather than silently ignoring them (BR-25).
- Ownership is applied server-side from `X-Requester-Id`; no parameter can widen the scope (BR-14).
- Search is a case-insensitive substring of ticket number or summary; category, related system, priority and status filters AND together.
- Sort is `createdAt | updatedAt | ticketNumber | requestedPriority` in either direction, always with `id desc` as the deterministic secondary sort (BR-23).
- Page sizes are limited to 5/10/20/50; a page past the end returns 200 with an empty `items` array and correct metadata (BR-27).
- `attachmentCount` counts active attachments only, so soft-removed ones do not inflate it.

**Frontend**
- Toolbar with search (debounced, one request per pause rather than per keystroke), four filters, sort, page size, Clear filters, and Create Ticket.
- One responsive table: desktop columns, Related System hidden at tablet width, and the same rows become cards below 768 px through CSS `data-label` — one DOM, so nothing is duplicated for screen readers.
- Priority and status badges carry their value as text, not colour alone (AC-38).
- Pagination shows "Showing X–Y of Z" and disables Previous/Next at the ends instead of hiding them.
- Distinct loading, empty, no-results (with Clear filters) and failure (with Retry) states (BR-30).
- Switching requester resets to page 1 and reloads for the new identity (BR-08).

Also adds `client/tests/lab-02/zen-green.style.test.tsx` covering STYLE-01…STYLE-05 from the test plan.

## Verification
- Server 44/44 pass — UNIT-05 plus API-07…API-14, including cross-requester isolation, the 400 cases, and the past-the-end page.
- Client 39/39 pass — UI-10…UI-14 and STYLE-01…05.
- `tsc --noEmit` clean on both sides.
- Manual with 12 demo tickets for Napat and 3 for Chanya: priority filter narrowed 12 → 3, a nonsense search showed the no-results state, and switching to Chanya replaced the list with only her three tickets. No horizontal page scroll at 1280.

Closes #17