### PR TITLE
Lab 2 Issue 6: Requester Ticket Detail and attachment lifecycle

### DIFF
--- a/client/src/AppRoot.tsx
+++ b/client/src/AppRoot.tsx
@@ -5,6 +5,7 @@ import AppShell from "./components/AppShell.js";
 import RequesterSelection from "./pages/RequesterSelection.js";
 import MyTickets from "./pages/MyTickets.js";
 import CreateTicket from "./pages/CreateTicket.js";
+import RequesterTicketDetail from "./pages/RequesterTicketDetail.js";
 import App from "./App.js";
 
 export function AppRoutes() {
@@ -24,6 +25,7 @@ export function AppRoutes() {
       >
         <Route path="/tickets" element={<MyTickets />} />
         <Route path="/tickets/new" element={<CreateTicket />} />
+        <Route path="/tickets/:id" element={<RequesterTicketDetail />} />
       </Route>
 
       <Route path="*" element={<Navigate to="/tickets" replace />} />

--- a/client/src/api/attachments.ts
+++ b/client/src/api/attachments.ts
@@ -1,0 +1,78 @@
+import { apiFetch, apiFetchBlob } from "./client.js";
+
+// Attachment rules mirrored from the backend (BR-31 … BR-33); the backend
+// remains the authority and re-checks every one of them.
+export const MAX_FILE_BYTES = 5 * 1024 * 1024;
+export const MAX_ACTIVE_ATTACHMENTS = 5;
+export const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
+export const ALLOWED_ACCEPT = ".jpg,.jpeg,.png,.webp,.pdf,image/jpeg,image/png,image/webp,application/pdf";
+export const ATTACHMENT_RULES_TEXT = "JPG, PNG, WEBP or PDF · max 5 MB each · up to 5 active files";
+
+export interface Attachment {
+  id: number;
+  ticketId: number;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  uploadedAt: string;
+  uploadedBy: { id: number; name: string };
+  state: "ACTIVE" | "REMOVED";
+  removedAt?: string;
+  removalReason?: string;
+  removedBy?: { id: number; name: string } | null;
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Returns the reason a file is not acceptable, or null when it is fine. */
+export function checkFile(file: File): string | null {
+  const extension = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
+  if (!ALLOWED_EXTENSIONS.includes(extension)) {
+    return `${file.name}: only JPG, PNG, WEBP and PDF files are allowed`;
+  }
+  if (file.size > MAX_FILE_BYTES) {
+    return `${file.name}: each file must be 5 MB or smaller`;
+  }
+  return null;
+}
+
+export function listAttachments(ticketId: number): Promise<Attachment[]> {
+  return apiFetch<Attachment[]>(`/api/tickets/${ticketId}/attachments`, { withRequester: true });
+}
+
+export function uploadAttachment(ticketId: number, file: File): Promise<Attachment> {
+  const body = new FormData();
+  body.append("file", file);
+  // No Content-Type header: the browser adds the multipart boundary itself.
+  return apiFetch<Attachment>(`/api/tickets/${ticketId}/attachments`, {
+    method: "POST",
+    withRequester: true,
+    body,
+  });
+}
+
+export function removeAttachment(attachmentId: number, reason: string): Promise<Attachment> {
+  return apiFetch<Attachment>(`/api/attachments/${attachmentId}/remove`, {
+    method: "PATCH",
+    withRequester: true,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ reason }),
+  });
+}
+
+/** Fetches the bytes with the identity header, then hands them to the browser. */
+export async function downloadAttachment(attachment: Attachment): Promise<void> {
+  const { blob, filename } = await apiFetchBlob(`/api/attachments/${attachment.id}/download`);
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename ?? attachment.originalFilename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -64,3 +64,27 @@ export async function apiFetch<T>(path: string, options: RequestOptions = {}): P
   if (response.status === 204) return undefined as T;
   return (await response.json()) as T;
 }
+
+/** Downloads need the identity header too, so a plain <a href> will not do. */
+export async function apiFetchBlob(path: string): Promise<{ blob: Blob; filename: string | null }> {
+  const headers = new Headers();
+  const requesterId = getStoredRequesterId();
+  if (requesterId !== null) headers.set("X-Requester-Id", String(requesterId));
+
+  const response = await fetch(`${API_URL}${path}`, { headers });
+
+  if (!response.ok) {
+    let message = "Unable to download this file.";
+    try {
+      const body = await response.json();
+      if (typeof body?.error === "string") message = body.error;
+    } catch {
+      // Keep the generic message.
+    }
+    throw new ApiError(response.status, message);
+  }
+
+  const disposition = response.headers.get("Content-Disposition") ?? "";
+  const match = /filename="([^"]+)"/.exec(disposition);
+  return { blob: await response.blob(), filename: match ? match[1] : null };
+}

--- a/client/src/api/tickets.ts
+++ b/client/src/api/tickets.ts
@@ -85,3 +85,7 @@ export function listTickets(params: TicketListParams): Promise<TicketListRespons
     withRequester: true,
   });
 }
+
+export function getTicket(id: number): Promise<Ticket> {
+  return apiFetch<Ticket>(`/api/tickets/${id}`, { withRequester: true });
+}

--- a/client/src/components/AttachmentSection.tsx
+++ b/client/src/components/AttachmentSection.tsx
@@ -1,0 +1,261 @@
+import { useRef, useState, ChangeEvent } from "react";
+import {
+  ALLOWED_ACCEPT,
+  ATTACHMENT_RULES_TEXT,
+  Attachment,
+  MAX_ACTIVE_ATTACHMENTS,
+  checkFile,
+  downloadAttachment,
+  formatFileSize,
+  removeAttachment,
+  uploadAttachment,
+} from "../api/attachments.js";
+import { ApiError } from "../api/client.js";
+
+// Attachment section — docs/lab-02/ui-spec.md §7.4.
+
+interface Props {
+  ticketId: number;
+  attachments: Attachment[];
+  onChange: (attachments: Attachment[]) => void;
+}
+
+export default function AttachmentSection({ ticketId, attachments, onChange }: Props) {
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+
+  const [removalTarget, setRemovalTarget] = useState<Attachment | null>(null);
+  const [reason, setReason] = useState("");
+  const [reasonError, setReasonError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState(false);
+
+  const activeCount = attachments.filter((a) => a.state === "ACTIVE").length;
+  const limitReached = activeCount >= MAX_ACTIVE_ATTACHMENTS;
+
+  async function handleFileSelected(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = ""; // allow the same file to be chosen again after an error
+    if (!file) return;
+
+    setDownloadError(null);
+    const problem = checkFile(file);
+    if (problem) {
+      setUploadError(problem);
+      return;
+    }
+
+    setUploadError(null);
+    setUploading(true);
+    try {
+      const created = await uploadAttachment(ticketId, file);
+      onChange([...attachments, created]);
+    } catch (error) {
+      setUploadError(
+        error instanceof ApiError ? error.message : "Unable to upload this file. Please try again."
+      );
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleDownload(attachment: Attachment) {
+    setDownloadError(null);
+    try {
+      await downloadAttachment(attachment);
+    } catch (error) {
+      setDownloadError(
+        error instanceof ApiError ? error.message : "Unable to download this file. Please try again."
+      );
+    }
+  }
+
+  function openRemoval(attachment: Attachment) {
+    setRemovalTarget(attachment);
+    setReason("");
+    setReasonError(null);
+  }
+
+  async function confirmRemoval() {
+    if (!removalTarget) return;
+
+    // BR-37 — a reason is required before anything is removed.
+    if (reason.trim().length < 3) {
+      setReasonError("Reason must be at least 3 characters");
+      return;
+    }
+
+    setRemoving(true);
+    try {
+      const removed = await removeAttachment(removalTarget.id, reason.trim());
+      onChange(attachments.map((a) => (a.id === removed.id ? removed : a)));
+      setRemovalTarget(null);
+    } catch (error) {
+      setReasonError(
+        error instanceof ApiError ? error.message : "Unable to remove this file. Please try again."
+      );
+    } finally {
+      setRemoving(false);
+    }
+  }
+
+  return (
+    <section className="zg-card mt-4" aria-labelledby="attachments-heading">
+      <h2 className="zg-section-title" id="attachments-heading">
+        Attachments
+      </h2>
+
+      <p className="zg-muted">
+        {activeCount} of {MAX_ACTIVE_ATTACHMENTS} active attachments · {ATTACHMENT_RULES_TEXT}
+      </p>
+
+      {uploadError && (
+        <div className="zg-callout zg-callout-error" role="alert">
+          {uploadError}
+        </div>
+      )}
+
+      {downloadError && (
+        <div className="zg-callout zg-callout-error" role="alert">
+          {downloadError}
+        </div>
+      )}
+
+      {attachments.length === 0 && (
+        <p className="zg-muted" role="status">
+          No attachments yet.
+        </p>
+      )}
+
+      <ul className="zg-attachment-list">
+        {attachments.map((attachment) => {
+          const removed = attachment.state === "REMOVED";
+          return (
+            <li key={attachment.id} className={removed ? "zg-attachment zg-attachment-removed" : "zg-attachment"}>
+              <div>
+                <p className="mb-1">
+                  <span className="zg-attachment-name">{attachment.originalFilename}</span>{" "}
+                  <span className={removed ? "zg-badge zg-badge-removed" : "zg-badge zg-badge-active"}>
+                    {removed ? "Removed" : "Active"}
+                  </span>
+                </p>
+                <p className="zg-muted mb-0">
+                  {formatFileSize(attachment.sizeBytes)} · uploaded{" "}
+                  {new Date(attachment.uploadedAt).toLocaleString()} by {attachment.uploadedBy.name}
+                </p>
+                {removed && (
+                  <p className="zg-muted mb-0">
+                    Removed {attachment.removedAt ? new Date(attachment.removedAt).toLocaleString() : ""} ·
+                    reason: {attachment.removalReason}
+                  </p>
+                )}
+              </div>
+
+              <div className="d-flex gap-2">
+                <button
+                  type="button"
+                  className="zg-btn zg-btn-secondary"
+                  onClick={() => handleDownload(attachment)}
+                  disabled={removed}
+                  title={removed ? "A removed attachment cannot be downloaded" : `Download ${attachment.originalFilename}`}
+                  aria-label={`Download ${attachment.originalFilename}`}
+                >
+                  Download
+                </button>
+                <button
+                  type="button"
+                  className="zg-btn zg-btn-destructive"
+                  onClick={() => openRemoval(attachment)}
+                  disabled={removed}
+                  aria-label={`Remove ${attachment.originalFilename}`}
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <input
+        ref={fileInput}
+        id="attachmentFile"
+        type="file"
+        className="visually-hidden"
+        accept={ALLOWED_ACCEPT}
+        onChange={handleFileSelected}
+      />
+
+      <button
+        type="button"
+        className="zg-btn zg-btn-primary"
+        onClick={() => fileInput.current?.click()}
+        disabled={limitReached || uploading}
+      >
+        {uploading ? "Uploading…" : "Add attachment"}
+      </button>
+
+      {limitReached && (
+        <p className="zg-muted mt-2" role="status">
+          This ticket already has {MAX_ACTIVE_ATTACHMENTS} active attachments. Remove one before adding
+          another.
+        </p>
+      )}
+
+      {removalTarget && (
+        <div className="zg-modal" role="dialog" aria-modal="true" aria-labelledby="removal-heading">
+          <div className="zg-modal-panel">
+            <h3 className="zg-section-title" id="removal-heading">
+              Remove attachment
+            </h3>
+            <p>
+              <strong>{removalTarget.originalFilename}</strong> stays visible as metadata but can no longer
+              be downloaded.
+            </p>
+
+            <div className="zg-field">
+              <label className="zg-label" htmlFor="removalReason">
+                Reason
+                <span className="zg-required" aria-hidden="true">
+                  *
+                </span>
+              </label>
+              <textarea
+                id="removalReason"
+                className={reasonError ? "zg-textarea zg-invalid" : "zg-textarea"}
+                rows={3}
+                maxLength={200}
+                required
+                aria-required="true"
+                aria-invalid={reasonError ? true : undefined}
+                aria-describedby={reasonError ? "removalReason-error" : undefined}
+                value={reason}
+                onChange={(event) => setReason(event.target.value)}
+              />
+              {reasonError && (
+                <span className="zg-message zg-message-error" id="removalReason-error">
+                  {reasonError}
+                </span>
+              )}
+            </div>
+
+            <div className="d-flex flex-wrap gap-2">
+              <button type="button" className="zg-btn zg-btn-destructive" onClick={confirmRemoval} disabled={removing}>
+                {removing ? "Removing…" : "Remove"}
+              </button>
+              <button
+                type="button"
+                className="zg-btn zg-btn-secondary"
+                onClick={() => setRemovalTarget(null)}
+                disabled={removing}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/pages/CreateTicket.tsx
+++ b/client/src/pages/CreateTicket.tsx
@@ -3,6 +3,14 @@ import { Link } from "react-router-dom";
 import { ApiError } from "../api/client.js";
 import { getCategories, getRelatedSystems, ReferenceItem } from "../api/reference.js";
 import { createTicket, Priority, Ticket } from "../api/tickets.js";
+import {
+  ALLOWED_ACCEPT,
+  ATTACHMENT_RULES_TEXT,
+  MAX_ACTIVE_ATTACHMENTS,
+  checkFile,
+  formatFileSize,
+  uploadAttachment,
+} from "../api/attachments.js";
 import { useRequester } from "../context/RequesterContext.js";
 
 // Create Ticket — docs/lab-02/ui-spec.md §7.2, api-spec.md §3.1.
@@ -70,6 +78,10 @@ export default function CreateTicket() {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [created, setCreated] = useState<Ticket | null>(null);
 
+  const [files, setFiles] = useState<File[]>([]);
+  const [fileErrors, setFileErrors] = useState<string[]>([]);
+  const [uploadFailures, setUploadFailures] = useState<string[]>([]);
+
   useEffect(() => {
     let cancelled = false;
     setReferenceState("loading");
@@ -100,6 +112,36 @@ export default function CreateTicket() {
     });
   }
 
+  function handleFilesSelected(event: React.ChangeEvent<HTMLInputElement>) {
+    const selected = Array.from(event.target.files ?? []);
+    event.target.value = "";
+    if (selected.length === 0) return;
+
+    const accepted: File[] = [];
+    const problems: string[] = [];
+
+    for (const file of selected) {
+      const problem = checkFile(file);
+      if (problem) {
+        problems.push(problem);
+        continue;
+      }
+      if (files.length + accepted.length >= MAX_ACTIVE_ATTACHMENTS) {
+        problems.push(`${file.name}: a ticket can have at most ${MAX_ACTIVE_ATTACHMENTS} attachments`);
+        continue;
+      }
+      accepted.push(file);
+    }
+
+    // AC-14 — invalid files are reported by name; valid selections stay.
+    setFiles((current) => [...current, ...accepted]);
+    setFileErrors(problems);
+  }
+
+  function removeSelectedFile(index: number) {
+    setFiles((current) => current.filter((_, i) => i !== index));
+  }
+
   async function handleSubmit(event: FormEvent) {
     event.preventDefault();
     setSubmitError(null);
@@ -119,6 +161,20 @@ export default function CreateTicket() {
         summary: values.summary.trim(),
         description: values.description.trim(),
       });
+      // BR-41 — the ticket is never rolled back because an upload failed;
+      // each failure is reported per file so it can be retried from the ticket.
+      const failures: string[] = [];
+      for (const file of files) {
+        try {
+          await uploadAttachment(ticket.id, file);
+        } catch (error) {
+          failures.push(
+            `${file.name}: ${error instanceof ApiError ? error.message : "upload failed, you can retry it on the ticket"}`
+          );
+        }
+      }
+
+      setUploadFailures(failures);
       setCreated(ticket);
       setErrors({});
     } catch (error) {
@@ -141,6 +197,9 @@ export default function CreateTicket() {
     setValues(EMPTY_FORM);
     setErrors({});
     setSubmitError(null);
+    setFiles([]);
+    setFileErrors([]);
+    setUploadFailures([]);
   }
 
   function messageFor(field: keyof FormValues) {
@@ -175,6 +234,17 @@ export default function CreateTicket() {
               Ticket Number: <strong>{created.ticketNumber}</strong>
             </p>
           </div>
+
+          {uploadFailures.length > 0 && (
+            <div className="zg-callout zg-callout-warning" role="alert">
+              <p className="mb-1">The ticket was saved, but some attachments did not upload:</p>
+              <ul className="mb-0">
+                {uploadFailures.map((failure) => (
+                  <li key={failure}>{failure}</li>
+                ))}
+              </ul>
+            </div>
+          )}
           <div className="d-flex flex-wrap gap-2">
             <Link className="zg-btn zg-btn-primary" to={`/tickets/${created.id}`}>
               View Ticket
@@ -371,8 +441,46 @@ export default function CreateTicket() {
           </span>
         </div>
 
-        <div className="zg-callout zg-callout-info" role="note">
-          Attachments can be added on the ticket after it is created.
+        <div className="zg-field">
+          <label className="zg-label" htmlFor="attachments">
+            Attachments
+          </label>
+          <input
+            id="attachments"
+            className="zg-input"
+            type="file"
+            multiple
+            accept={ALLOWED_ACCEPT}
+            onChange={handleFilesSelected}
+          />
+          <span className="zg-muted">{ATTACHMENT_RULES_TEXT}</span>
+
+          {fileErrors.map((message) => (
+            <span key={message} className="zg-message zg-message-error">
+              {message}
+            </span>
+          ))}
+
+          {files.length > 0 && (
+            <ul className="zg-attachment-list mt-2">
+              {files.map((file, index) => (
+                <li key={`${file.name}-${index}`} className="zg-attachment">
+                  <span>
+                    <span className="zg-attachment-name">{file.name}</span>{" "}
+                    <span className="zg-muted">{formatFileSize(file.size)}</span>
+                  </span>
+                  <button
+                    type="button"
+                    className="zg-btn zg-btn-tertiary"
+                    onClick={() => removeSelectedFile(index)}
+                    aria-label={`Remove ${file.name} from the selection`}
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
 
         <div className="d-flex flex-wrap gap-2">

--- a/client/src/pages/RequesterTicketDetail.tsx
+++ b/client/src/pages/RequesterTicketDetail.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { ApiError } from "../api/client.js";
+import { getTicket, Ticket } from "../api/tickets.js";
+import { Attachment } from "../api/attachments.js";
+import { PriorityBadge, StatusBadge } from "../components/Badges.js";
+import AttachmentSection from "../components/AttachmentSection.js";
+
+// Requester Ticket Detail (view mode) — docs/lab-02/ui-spec.md §7.5.
+// Every ticket field is read-only here (BR-04, AC-25).
+
+type LoadState = "loading" | "ready" | "notFound" | "failed";
+
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+  const id = `field-${label.toLowerCase().replace(/[^a-z]+/g, "-")}`;
+  return (
+    <div className="col-12 col-lg-4 zg-field">
+      <label className="zg-label" htmlFor={id}>
+        {label}
+      </label>
+      <input id={id} className="zg-input zg-readonly" readOnly aria-readonly="true" value={value} />
+    </div>
+  );
+}
+
+export default function RequesterTicketDetail() {
+  const { id } = useParams();
+  const ticketId = Number(id);
+
+  const [state, setState] = useState<LoadState>("loading");
+  const [ticket, setTicket] = useState<Ticket | null>(null);
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    if (!Number.isInteger(ticketId)) {
+      setState("notFound");
+      return;
+    }
+
+    let cancelled = false;
+    setState("loading");
+
+    getTicket(ticketId)
+      .then((loaded) => {
+        if (cancelled) return;
+        setTicket(loaded);
+        setAttachments((loaded.attachments as Attachment[]) ?? []);
+        setState("ready");
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        // 404 covers both "missing" and "not yours" (BR-13).
+        setState(error instanceof ApiError && error.status === 404 ? "notFound" : "failed");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ticketId, reloadToken]);
+
+  if (state === "loading") {
+    return (
+      <main className="zg-page">
+        <p role="status" aria-live="polite">
+          Loading ticket…
+        </p>
+      </main>
+    );
+  }
+
+  if (state === "notFound") {
+    return (
+      <main className="zg-page">
+        <div className="zg-callout zg-callout-error" role="alert">
+          <p className="mb-2">Ticket not found. It may not exist, or it belongs to another Requester.</p>
+          <Link className="zg-btn zg-btn-secondary" to="/tickets">
+            Back to My Tickets
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  if (state === "failed" || !ticket) {
+    return (
+      <main className="zg-page">
+        <div className="zg-callout zg-callout-error" role="alert">
+          <p className="mb-2">Unable to load this ticket.</p>
+          <button type="button" className="zg-btn zg-btn-secondary" onClick={() => setReloadToken((t) => t + 1)}>
+            Retry
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="zg-page">
+      <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <div className="d-flex align-items-center gap-3">
+          <h1 className="zg-page-title mb-0">{ticket.ticketNumber}</h1>
+          <StatusBadge value={ticket.status} />
+        </div>
+        <Link className="zg-btn zg-btn-secondary" to="/tickets">
+          Back to My Tickets
+        </Link>
+      </div>
+
+      <section className="zg-card" aria-label="Ticket information">
+        <div className="row g-3">
+          <ReadOnlyField label="Ticket Number" value={ticket.ticketNumber} />
+          <ReadOnlyField label="Ticket Date" value={new Date(ticket.createdAt).toLocaleString()} />
+          <ReadOnlyField label="Requester" value={ticket.requester.name} />
+          <ReadOnlyField label="Category" value={ticket.category.name} />
+          <ReadOnlyField label="Related System" value={ticket.relatedSystem.name} />
+          <ReadOnlyField label="Last Updated" value={new Date(ticket.updatedAt).toLocaleString()} />
+        </div>
+
+        <div className="zg-field">
+          <span className="zg-label">Requested Priority</span>
+          <div>
+            <PriorityBadge value={ticket.requestedPriority} />
+          </div>
+        </div>
+
+        <div className="zg-field">
+          <label className="zg-label" htmlFor="detail-summary">
+            Summary
+          </label>
+          <input
+            id="detail-summary"
+            className="zg-input zg-readonly"
+            readOnly
+            aria-readonly="true"
+            value={ticket.summary}
+          />
+        </div>
+
+        <div className="zg-field mb-0">
+          <label className="zg-label" htmlFor="detail-description">
+            Description
+          </label>
+          <textarea
+            id="detail-description"
+            className="zg-textarea zg-readonly"
+            readOnly
+            aria-readonly="true"
+            rows={5}
+            value={ticket.description}
+          />
+        </div>
+      </section>
+
+      <AttachmentSection ticketId={ticket.id} attachments={attachments} onChange={setAttachments} />
+    </main>
+  );
+}

--- a/client/src/styles/zen-green.css
+++ b/client/src/styles/zen-green.css
@@ -500,3 +500,56 @@ a:focus-visible {
     white-space: normal;
   }
 }
+
+/* ---------- attachments ---------- */
+
+.zg-attachment-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--zg-space-4);
+}
+
+.zg-attachment {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--zg-space-3);
+  padding: var(--zg-space-3) 0;
+  border-bottom: 1px solid var(--zg-border);
+}
+
+.zg-attachment:last-child {
+  border-bottom: none;
+}
+
+.zg-attachment-name {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.zg-attachment-removed .zg-attachment-name {
+  color: var(--zg-text-muted);
+  text-decoration: line-through;
+}
+
+/* ---------- modal ---------- */
+
+.zg-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(27, 43, 34, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--zg-space-4);
+  z-index: 1000;
+}
+
+.zg-modal-panel {
+  background: var(--zg-surface);
+  border-radius: var(--zg-radius);
+  padding: var(--zg-space-6);
+  width: 100%;
+  max-width: 480px;
+}

--- a/client/tests/lab-02/AttachmentSection.test.tsx
+++ b/client/tests/lab-02/AttachmentSection.test.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as attachmentsApi from "../../src/api/attachments.js";
+import { ApiError } from "../../src/api/client.js";
+import AttachmentSection from "../../src/components/AttachmentSection.js";
+
+// UI-17 … UI-20 — docs/lab-02/tests.md §2.3
+
+function attachment(overrides: Partial<attachmentsApi.Attachment> = {}): attachmentsApi.Attachment {
+  return {
+    id: 9,
+    ticketId: 42,
+    originalFilename: "battery-report.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 184320,
+    uploadedAt: "2026-08-12T04:20:10.004Z",
+    uploadedBy: { id: 1, name: "Napat Srisai" },
+    state: "ACTIVE",
+    ...overrides,
+  };
+}
+
+function pngFile(name = "screenshot.png", size = 1024) {
+  const file = new File([new Uint8Array(size)], name, { type: "image/png" });
+  Object.defineProperty(file, "size", { value: size });
+  return file;
+}
+
+/** Renders the section with state, the way Ticket Detail owns it. */
+function Harness({ initial }: { initial: attachmentsApi.Attachment[] }) {
+  const [items, setItems] = useState(initial);
+  return <AttachmentSection ticketId={42} attachments={items} onChange={setItems} />;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Attachment section", () => {
+  // UI-17 / AC-27
+  it("adds a successfully uploaded file to the list as Active", async () => {
+    const uploaded = attachment({ id: 10, originalFilename: "screenshot.png", mimeType: "image/png" });
+    const spy = vi.spyOn(attachmentsApi, "uploadAttachment").mockResolvedValue(uploaded);
+
+    render(<Harness initial={[]} />);
+
+    expect(screen.getByText(/no attachments yet/i)).toBeInTheDocument();
+
+    await userEvent.upload(document.querySelector("#attachmentFile") as HTMLInputElement, pngFile());
+
+    expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText(/1 of 5 active attachments/i)).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledWith(42, expect.any(File));
+  });
+
+  // UI-17 / AC-14, BR-31 — client-side type rule before any request
+  it("rejects a disallowed file type without calling the API", async () => {
+    const spy = vi.spyOn(attachmentsApi, "uploadAttachment");
+
+    render(<Harness initial={[]} />);
+
+    // The accept attribute filters the picker, so a file chosen through "All
+    // files" is simulated directly — that is what the guard has to catch.
+    fireEvent.change(document.querySelector("#attachmentFile") as HTMLInputElement, {
+      target: { files: [new File(["MZ"], "setup.exe", { type: "application/x-msdownload" })] },
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/only jpg, png, webp and pdf/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // UI-17 / AC-14, BR-32 — client-side size rule before any request
+  it("rejects a file larger than 5 MB without calling the API", async () => {
+    const spy = vi.spyOn(attachmentsApi, "uploadAttachment");
+
+    render(<Harness initial={[]} />);
+
+    await userEvent.upload(
+      document.querySelector("#attachmentFile") as HTMLInputElement,
+      pngFile("huge.png", 6 * 1024 * 1024)
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/5 mb or smaller/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an upload failure from the API", async () => {
+    vi.spyOn(attachmentsApi, "uploadAttachment").mockRejectedValue(
+      new ApiError(409, "A ticket can have at most 5 active attachments")
+    );
+
+    render(<Harness initial={[]} />);
+    await userEvent.upload(document.querySelector("#attachmentFile") as HTMLInputElement, pngFile());
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/at most 5 active attachments/i);
+  });
+
+  // UI-18 / AC-28
+  it("disables Add and explains why once five attachments are active", () => {
+    const five = Array.from({ length: 5 }, (_, i) =>
+      attachment({ id: i + 1, originalFilename: `evidence-${i}.png` })
+    );
+
+    render(<Harness initial={five} />);
+
+    expect(screen.getByRole("button", { name: /add attachment/i })).toBeDisabled();
+    expect(screen.getByText(/already has 5 active attachments/i)).toBeInTheDocument();
+    expect(screen.getByText(/5 of 5 active attachments/i)).toBeInTheDocument();
+  });
+
+  // UI-19 / AC-30, AC-34, BR-37
+  it("requires a confirmation and a reason before removing", async () => {
+    const removeSpy = vi.spyOn(attachmentsApi, "removeAttachment").mockResolvedValue(
+      attachment({
+        state: "REMOVED",
+        removedAt: "2026-08-12T06:00:00.000Z",
+        removalReason: "Uploaded the wrong file",
+        removedBy: { id: 1, name: "Napat Srisai" },
+      })
+    );
+
+    render(<Harness initial={[attachment()]} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /remove battery-report\.pdf/i }));
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent(/stays visible as metadata/i);
+
+    // Too short: blocked before any request.
+    await userEvent.type(screen.getByLabelText(/^Reason/), "ab");
+    await userEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+    expect(screen.getByText(/reason must be at least 3 characters/i)).toBeInTheDocument();
+    expect(removeSpy).not.toHaveBeenCalled();
+
+    await userEvent.clear(screen.getByLabelText(/^Reason/));
+    await userEvent.type(screen.getByLabelText(/^Reason/), "Uploaded the wrong file");
+    await userEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+    await waitFor(() => expect(removeSpy).toHaveBeenCalledWith(9, "Uploaded the wrong file"));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes the removal dialog on Cancel without removing anything", async () => {
+    const removeSpy = vi.spyOn(attachmentsApi, "removeAttachment");
+
+    render(<Harness initial={[attachment()]} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /remove battery-report\.pdf/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  // UI-20 / AC-31, BR-39
+  it("keeps a removed attachment visible with its reason and blocks its download", () => {
+    render(
+      <Harness
+        initial={[
+          attachment({
+            state: "REMOVED",
+            removedAt: "2026-08-12T06:00:00.000Z",
+            removalReason: "Uploaded the wrong file",
+            removedBy: { id: 1, name: "Napat Srisai" },
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("battery-report.pdf")).toBeInTheDocument();
+    expect(screen.getByText("Removed")).toBeInTheDocument();
+    expect(screen.getByText(/uploaded the wrong file/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /download battery-report\.pdf/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /remove battery-report\.pdf/i })).toBeDisabled();
+    expect(screen.getByText(/0 of 5 active attachments/i)).toBeInTheDocument();
+  });
+
+  // AC-29
+  it("downloads an active attachment through the API layer", async () => {
+    const spy = vi.spyOn(attachmentsApi, "downloadAttachment").mockResolvedValue(undefined);
+
+    render(<Harness initial={[attachment()]} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /download battery-report\.pdf/i }));
+
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ id: 9 }));
+  });
+
+  it("reports a failed download without breaking the list", async () => {
+    vi.spyOn(attachmentsApi, "downloadAttachment").mockRejectedValue(
+      new ApiError(410, "This attachment has been removed")
+    );
+
+    render(<Harness initial={[attachment()]} />);
+    await userEvent.click(screen.getByRole("button", { name: /download battery-report\.pdf/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/has been removed/i);
+    expect(screen.getByText("battery-report.pdf")).toBeInTheDocument();
+  });
+});

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import * as reference from "../../src/api/reference.js";
 import * as tickets from "../../src/api/tickets.js";
+import * as attachments from "../../src/api/attachments.js";
 import { ApiError, REQUESTER_STORAGE_KEY } from "../../src/api/client.js";
 import { RequesterProvider } from "../../src/context/RequesterContext.js";
 import CreateTicket from "../../src/pages/CreateTicket.js";
@@ -238,5 +239,74 @@ describe("Create Ticket", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/unable to load categories/i);
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  // UI-09 / AC-14, BR-31, BR-32
+  it("rejects an invalid attachment by name and keeps the valid one selected", async () => {
+    renderCreateTicket();
+
+    const picker = await screen.findByLabelText(/^Attachments/);
+    const validFile = new File([new Uint8Array(1024)], "evidence.png", { type: "image/png" });
+    const oversized = new File([new Uint8Array(8)], "huge.png", { type: "image/png" });
+    Object.defineProperty(oversized, "size", { value: 6 * 1024 * 1024 });
+
+    fireEvent.change(picker, {
+      target: {
+        files: [
+          validFile,
+          oversized,
+          new File(["MZ"], "setup.exe", { type: "application/x-msdownload" }),
+        ],
+      },
+    });
+
+    expect(await screen.findByText(/huge\.png: each file must be 5 MB or smaller/i)).toBeInTheDocument();
+    expect(screen.getByText(/setup\.exe: only JPG, PNG, WEBP and PDF/i)).toBeInTheDocument();
+    expect(screen.getByText("evidence.png")).toBeInTheDocument();
+  });
+
+  // BR-41 — an attachment failure never rolls back a saved ticket
+  it("keeps the created ticket and reports the file when an upload fails", async () => {
+    vi.spyOn(tickets, "createTicket").mockResolvedValue(createdTicket());
+    vi.spyOn(attachments, "uploadAttachment").mockRejectedValue(new Error("upload down"));
+
+    renderCreateTicket();
+    await fillValidForm();
+
+    fireEvent.change(screen.getByLabelText(/^Attachments/), {
+      target: { files: [new File([new Uint8Array(16)], "evidence.png", { type: "image/png" })] },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    expect(await screen.findByText("TKT-2026-000042")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/some attachments did not upload/i);
+    expect(screen.getByText(/evidence\.png/)).toBeInTheDocument();
+  });
+
+  it("uploads each selected attachment after the ticket is created", async () => {
+    vi.spyOn(tickets, "createTicket").mockResolvedValue(createdTicket());
+    const uploadSpy = vi.spyOn(attachments, "uploadAttachment").mockResolvedValue({
+      id: 5,
+      ticketId: 42,
+      originalFilename: "evidence.png",
+      mimeType: "image/png",
+      sizeBytes: 16,
+      uploadedAt: "2026-08-12T04:20:10.004Z",
+      uploadedBy: { id: 1, name: "Napat Srisai" },
+      state: "ACTIVE",
+    });
+
+    renderCreateTicket();
+    await fillValidForm();
+
+    fireEvent.change(screen.getByLabelText(/^Attachments/), {
+      target: { files: [new File([new Uint8Array(16)], "evidence.png", { type: "image/png" })] },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    await waitFor(() => expect(uploadSpy).toHaveBeenCalledWith(42, expect.any(File)));
+    expect(await screen.findByText("TKT-2026-000042")).toBeInTheDocument();
   });
 });

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import * as reference from "../../src/api/reference.js";
+import * as ticketsApi from "../../src/api/tickets.js";
+import { ApiError, REQUESTER_STORAGE_KEY } from "../../src/api/client.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import RequesterTicketDetail from "../../src/pages/RequesterTicketDetail.js";
+
+// UI-15, UI-16 — docs/lab-02/tests.md §2.3
+
+const TICKET: ticketsApi.Ticket = {
+  id: 42,
+  ticketNumber: "TKT-2026-000042",
+  status: "NEW",
+  requestedPriority: "HIGH",
+  summary: "Laptop battery drains fast",
+  description: "The laptop discharges from full to empty within an hour even when idle on the desk.",
+  requester: { id: 1, name: "Napat Srisai" },
+  category: { id: 2, name: "Hardware" },
+  relatedSystem: { id: 7, name: "Corporate Laptop" },
+  createdAt: "2026-08-12T04:11:20.310Z",
+  updatedAt: "2026-08-12T05:00:00.000Z",
+  attachments: [],
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+  vi.spyOn(reference, "getRequesters").mockResolvedValue([
+    { id: 1, name: "Napat Srisai", email: "napat.sri@kmutt.ac.th", department: "Faculty of Engineering" },
+  ]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderDetail(path = "/tickets/42") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <RequesterProvider>
+        <Routes>
+          <Route path="/tickets/:id" element={<RequesterTicketDetail />} />
+          <Route path="/tickets" element={<h1>My Tickets</h1>} />
+        </Routes>
+      </RequesterProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("Requester Ticket Detail", () => {
+  // UI-15 / AC-25
+  it("shows every ticket field read-only with no editable header control", async () => {
+    vi.spyOn(ticketsApi, "getTicket").mockResolvedValue(TICKET);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "TKT-2026-000042" })).toBeInTheDocument();
+
+    for (const label of [/Ticket Number/, /Ticket Date/, /^Requester/, /^Category/, /Related System/, /^Summary/]) {
+      expect(screen.getByLabelText(label)).toHaveAttribute("readonly");
+    }
+    expect(screen.getByLabelText(/^Description/)).toHaveAttribute("readonly");
+
+    expect(screen.getByLabelText(/^Summary/)).toHaveValue("Laptop battery drains fast");
+    expect(screen.getByLabelText(/^Category/)).toHaveValue("Hardware");
+
+    // No control on the ticket header may be editable.
+    const editable = screen
+      .getAllByRole("textbox")
+      .filter((element) => !element.hasAttribute("readonly"));
+    expect(editable).toHaveLength(0);
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("shows the priority and status as badges with readable text", async () => {
+    vi.spyOn(ticketsApi, "getTicket").mockResolvedValue(TICKET);
+
+    renderDetail();
+
+    expect(await screen.findByText("High")).toBeInTheDocument();
+    expect(screen.getByText("New")).toBeInTheDocument();
+  });
+
+  // UI-16 / AC-26, BR-13
+  it("shows a not-found state instead of ticket data when the API answers 404", async () => {
+    vi.spyOn(ticketsApi, "getTicket").mockRejectedValue(new ApiError(404, "Ticket not found"));
+
+    renderDetail();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/belongs to another requester/i);
+    expect(screen.queryByText("Laptop battery drains fast")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to my tickets/i })).toBeInTheDocument();
+  });
+
+  it("shows a retryable failure state for an unexpected error", async () => {
+    const spy = vi.spyOn(ticketsApi, "getTicket").mockRejectedValueOnce(new Error("network down"));
+    spy.mockResolvedValue(TICKET);
+
+    renderDetail();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/unable to load this ticket/i);
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("treats a non-numeric id as not found without calling the API", async () => {
+    const spy = vi.spyOn(ticketsApi, "getTicket");
+
+    renderDetail("/tickets/abc");
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/ticket not found/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^1.4.5-lts.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/multer": "^2.2.0",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
@@ -1065,6 +1067,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1272,6 +1284,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1324,6 +1342,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1424,6 +1459,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1465,6 +1515,12 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -1985,6 +2041,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2071,11 +2133,51 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
@@ -2236,6 +2338,12 @@
         "fsevents": "2.3.3"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2288,6 +2396,27 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.62.4",
@@ -2524,6 +2653,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2693,6 +2845,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2722,6 +2880,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -3393,6 +3557,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -11,15 +11,19 @@
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "vitest run"
   },
-  "prisma": { "seed": "tsx prisma/seed.ts" },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^2.2.0",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import { referenceRouter } from "./routes/reference.js";
 import { ticketsRouter } from "./routes/tickets.js";
+import { attachmentsRouter } from "./routes/attachments.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -20,5 +21,8 @@ app.use(referenceRouter);
 
 // Lab 2 — tickets.
 app.use(ticketsRouter);
+
+// Lab 2 — attachments.
+app.use(attachmentsRouter);
 
 export default app;

--- a/server/src/lib/attachments.ts
+++ b/server/src/lib/attachments.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Attachment rules — docs/lab-02/specification.md §5 (BR-31 … BR-35).
+
+export const MAX_FILE_BYTES = 5 * 1024 * 1024; // 5 MB (BR-32)
+export const MAX_ACTIVE_ATTACHMENTS = 5; // per ticket (BR-33)
+
+/** Allowed MIME type -> the extensions that may carry it (BR-31). */
+export const ALLOWED_TYPES: Record<string, string[]> = {
+  "image/jpeg": [".jpg", ".jpeg"],
+  "image/png": [".png"],
+  "image/webp": [".webp"],
+  "application/pdf": [".pdf"],
+};
+
+export const ALLOWED_LABEL = "Only JPG, PNG, WEBP and PDF files are allowed";
+
+const serverRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Files live outside the web root and are git-ignored (BR-35, D-04). */
+export const UPLOAD_DIR = path.join(serverRoot, "uploads");
+
+export function isAllowedType(mimeType: string, originalFilename: string): boolean {
+  const extensions = ALLOWED_TYPES[mimeType];
+  if (!extensions) return false;
+  const extension = path.extname(originalFilename).toLowerCase();
+  return extensions.includes(extension);
+}
+
+/**
+ * Server-generated storage name: a UUID plus the validated extension (BR-35).
+ * The original filename is never used as a path, so traversal and collisions
+ * are impossible.
+ */
+export function buildStoredFilename(mimeType: string, originalFilename: string): string {
+  const extension = path.extname(originalFilename).toLowerCase();
+  const allowed = ALLOWED_TYPES[mimeType] ?? [];
+  const safeExtension = allowed.includes(extension) ? extension : (allowed[0] ?? "");
+  return `${randomUUID()}${safeExtension}`;
+}
+
+export function storedFilePath(storedFilename: string): string {
+  // basename() strips any path element that could have crept in.
+  return path.join(UPLOAD_DIR, path.basename(storedFilename));
+}

--- a/server/src/lib/validation.ts
+++ b/server/src/lib/validation.ts
@@ -100,3 +100,10 @@ export function validateCreateTicket(body: unknown): ValidationResult {
     },
   };
 }
+
+// BR-37 — an attachment may only be removed with a stated reason.
+export function validateRemovalReason(raw: unknown): { errors: FieldError[]; value?: string } {
+  const errors: FieldError[] = [];
+  const value = validateText(raw, "reason", "Reason", 3, 200, errors);
+  return errors.length > 0 ? { errors } : { errors, value };
+}

--- a/server/src/routes/attachments.ts
+++ b/server/src/routes/attachments.ts
@@ -1,0 +1,316 @@
+import { Router, Request, Response } from "express";
+import multer from "multer";
+import { mkdir, writeFile, unlink, readFile } from "node:fs/promises";
+import { getPrisma } from "../prisma.js";
+import { resolveRequester, RequesterError } from "../lib/requester.js";
+import { validateRemovalReason } from "../lib/validation.js";
+import {
+  ALLOWED_LABEL,
+  MAX_ACTIVE_ATTACHMENTS,
+  MAX_FILE_BYTES,
+  UPLOAD_DIR,
+  buildStoredFilename,
+  isAllowedType,
+  storedFilePath,
+} from "../lib/attachments.js";
+
+// Attachment routes — contract: docs/lab-02/api-spec.md §4.
+
+export const attachmentsRouter = Router();
+
+// Kept in memory so the file is only written once it has passed every rule.
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: MAX_FILE_BYTES } });
+
+const attachmentSelect = {
+  id: true,
+  ticketId: true,
+  originalFilename: true,
+  mimeType: true,
+  sizeBytes: true,
+  uploadedAt: true,
+  removedAt: true,
+  removalReason: true,
+  uploadedBy: { select: { id: true, name: true } },
+  removedBy: { select: { id: true, name: true } },
+} as const;
+
+type AttachmentRow = {
+  id: number;
+  ticketId: number;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  uploadedAt: Date;
+  removedAt: Date | null;
+  removalReason: string | null;
+  uploadedBy: { id: number; name: string };
+  removedBy: { id: number; name: string } | null;
+};
+
+/** Removed attachments stay visible as metadata (BR-39). */
+export function serializeAttachment(row: AttachmentRow) {
+  const base = {
+    id: row.id,
+    ticketId: row.ticketId,
+    originalFilename: row.originalFilename,
+    mimeType: row.mimeType,
+    sizeBytes: row.sizeBytes,
+    uploadedAt: row.uploadedAt,
+    uploadedBy: row.uploadedBy,
+  };
+
+  if (!row.removedAt) return { ...base, state: "ACTIVE" as const };
+
+  return {
+    ...base,
+    state: "REMOVED" as const,
+    removedAt: row.removedAt,
+    removalReason: row.removalReason,
+    removedBy: row.removedBy,
+  };
+}
+
+function handleRequesterError(error: unknown, res: Response, fallback: string): boolean {
+  if (error instanceof RequesterError) {
+    res
+      .status(error.status)
+      .json(error.field ? { error: error.message, field: error.field } : { error: error.message });
+    return true;
+  }
+  res.status(500).json({ error: fallback });
+  return true;
+}
+
+/** BR-13 — a ticket owned by someone else is indistinguishable from a missing one. */
+async function findOwnedTicket(ticketId: number, requesterId: number) {
+  return getPrisma().ticket.findFirst({ where: { id: ticketId, requesterId }, select: { id: true } });
+}
+
+attachmentsRouter.get("/api/tickets/:id/attachments", async (req: Request, res: Response) => {
+  const ticketId = Number(req.params.id);
+  if (!Number.isInteger(ticketId)) {
+    res.status(400).json({ error: "Invalid ticket id" });
+    return;
+  }
+
+  let requesterId: number;
+  try {
+    requesterId = (await resolveRequester(req)).id;
+  } catch (error) {
+    handleRequesterError(error, res, "Unable to load attachments");
+    return;
+  }
+
+  try {
+    const ticket = await findOwnedTicket(ticketId, requesterId);
+    if (!ticket) {
+      res.status(404).json({ error: "Ticket not found" });
+      return;
+    }
+
+    const attachments = await getPrisma().attachment.findMany({
+      where: { ticketId },
+      orderBy: { id: "asc" },
+      select: attachmentSelect,
+    });
+
+    res.status(200).json(attachments.map(serializeAttachment));
+  } catch {
+    res.status(500).json({ error: "Unable to load attachments" });
+  }
+});
+
+attachmentsRouter.post(
+  "/api/tickets/:id/attachments",
+  (req: Request, res: Response, next) => {
+    upload.single("file")(req, res, (error: unknown) => {
+      if (error instanceof multer.MulterError) {
+        if (error.code === "LIMIT_FILE_SIZE") {
+          res.status(413).json({ error: "Each file must be 5 MB or smaller" });
+          return;
+        }
+        res.status(400).json({ error: "A file is required" });
+        return;
+      }
+      if (error) {
+        res.status(500).json({ error: "Unable to store the attachment" });
+        return;
+      }
+      next();
+    });
+  },
+  async (req: Request, res: Response) => {
+    const prisma = getPrisma();
+    const ticketId = Number(req.params.id);
+    if (!Number.isInteger(ticketId)) {
+      res.status(400).json({ error: "Invalid ticket id" });
+      return;
+    }
+
+    let requesterId: number;
+    try {
+      requesterId = (await resolveRequester(req)).id;
+    } catch (error) {
+      handleRequesterError(error, res, "Unable to store the attachment");
+      return;
+    }
+
+    const file = req.file;
+    if (!file) {
+      res.status(400).json({ error: "A file is required" });
+      return;
+    }
+
+    if (!isAllowedType(file.mimetype, file.originalname)) {
+      res.status(415).json({ error: ALLOWED_LABEL });
+      return;
+    }
+
+    let storedFilename: string | null = null;
+    try {
+      const ticket = await findOwnedTicket(ticketId, requesterId);
+      if (!ticket) {
+        res.status(404).json({ error: "Ticket not found" });
+        return;
+      }
+
+      // BR-33 — removed attachments do not count toward the limit.
+      const activeCount = await prisma.attachment.count({ where: { ticketId, removedAt: null } });
+      if (activeCount >= MAX_ACTIVE_ATTACHMENTS) {
+        res
+          .status(409)
+          .json({ error: `A ticket can have at most ${MAX_ACTIVE_ATTACHMENTS} active attachments` });
+        return;
+      }
+
+      storedFilename = buildStoredFilename(file.mimetype, file.originalname);
+      await mkdir(UPLOAD_DIR, { recursive: true });
+      await writeFile(storedFilePath(storedFilename), file.buffer);
+
+      const attachment = await prisma.attachment.create({
+        data: {
+          ticketId,
+          originalFilename: file.originalname,
+          storedFilename,
+          mimeType: file.mimetype,
+          sizeBytes: file.size,
+          uploadedByRequesterId: requesterId,
+        },
+        select: attachmentSelect,
+      });
+
+      res.status(201).json(serializeAttachment(attachment));
+    } catch {
+      // BR-42 — never leave a file on disk without its metadata row.
+      if (storedFilename) {
+        await unlink(storedFilePath(storedFilename)).catch(() => undefined);
+      }
+      res.status(500).json({ error: "Unable to store the attachment" });
+    }
+  }
+);
+
+attachmentsRouter.get("/api/attachments/:id/download", async (req: Request, res: Response) => {
+  const attachmentId = Number(req.params.id);
+  if (!Number.isInteger(attachmentId)) {
+    res.status(400).json({ error: "Invalid attachment id" });
+    return;
+  }
+
+  let requesterId: number;
+  try {
+    requesterId = (await resolveRequester(req)).id;
+  } catch (error) {
+    handleRequesterError(error, res, "Unable to read the attachment");
+    return;
+  }
+
+  try {
+    // BR-38 — ownership is checked through the parent ticket.
+    const attachment = await getPrisma().attachment.findFirst({
+      where: { id: attachmentId, ticket: { requesterId } },
+      select: {
+        originalFilename: true,
+        storedFilename: true,
+        mimeType: true,
+        removedAt: true,
+      },
+    });
+
+    if (!attachment) {
+      res.status(404).json({ error: "Attachment not found" });
+      return;
+    }
+
+    // BR-39 — a removed attachment is intentionally gone, not missing.
+    if (attachment.removedAt) {
+      res.status(410).json({ error: "This attachment has been removed" });
+      return;
+    }
+
+    const content = await readFile(storedFilePath(attachment.storedFilename));
+    res.setHeader("Content-Type", attachment.mimeType);
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${attachment.originalFilename.replace(/"/g, "")}"`
+    );
+    res.status(200).send(content);
+  } catch {
+    res.status(500).json({ error: "Unable to read the attachment" });
+  }
+});
+
+attachmentsRouter.patch("/api/attachments/:id/remove", async (req: Request, res: Response) => {
+  const prisma = getPrisma();
+  const attachmentId = Number(req.params.id);
+  if (!Number.isInteger(attachmentId)) {
+    res.status(400).json({ error: "Invalid attachment id" });
+    return;
+  }
+
+  let requesterId: number;
+  try {
+    requesterId = (await resolveRequester(req)).id;
+  } catch (error) {
+    handleRequesterError(error, res, "Unable to remove the attachment");
+    return;
+  }
+
+  const { errors, value: reason } = validateRemovalReason((req.body ?? {}).reason);
+  if (!reason) {
+    res.status(400).json({ error: "Validation failed", fields: errors });
+    return;
+  }
+
+  try {
+    const attachment = await prisma.attachment.findFirst({
+      where: { id: attachmentId, ticket: { requesterId } },
+      select: { id: true, removedAt: true },
+    });
+
+    if (!attachment) {
+      res.status(404).json({ error: "Attachment not found" });
+      return;
+    }
+
+    if (attachment.removedAt) {
+      res.status(409).json({ error: "This attachment has already been removed" });
+      return;
+    }
+
+    // BR-36 — soft removal only: the row and the metadata are kept.
+    const removed = await prisma.attachment.update({
+      where: { id: attachmentId },
+      data: {
+        removedAt: new Date(),
+        removalReason: reason,
+        removedByRequesterId: requesterId,
+      },
+      select: attachmentSelect,
+    });
+
+    res.status(200).json(serializeAttachment(removed));
+  } catch {
+    res.status(500).json({ error: "Unable to remove the attachment" });
+  }
+});

--- a/server/src/routes/tickets.ts
+++ b/server/src/routes/tickets.ts
@@ -5,6 +5,7 @@ import { resolveRequester, RequesterError } from "../lib/requester.js";
 import { validateCreateTicket } from "../lib/validation.js";
 import { formatTicketNumber } from "../lib/ticket-number.js";
 import { parseTicketListQuery } from "../lib/query.js";
+import { serializeAttachment } from "./attachments.js";
 
 // Ticket routes — contract: docs/lab-02/api-spec.md §3.
 
@@ -198,5 +199,57 @@ ticketsRouter.get("/api/tickets", async (req: Request, res: Response) => {
     });
   } catch {
     res.status(500).json({ error: "Unable to load tickets" });
+  }
+});
+
+ticketsRouter.get("/api/tickets/:id", async (req: Request, res: Response) => {
+  const ticketId = Number(req.params.id);
+  if (!Number.isInteger(ticketId)) {
+    res.status(400).json({ error: "Invalid ticket id" });
+    return;
+  }
+
+  let requesterId: number;
+  try {
+    requesterId = (await resolveRequester(req)).id;
+  } catch (error) {
+    if (handleRequesterError(error, res)) return;
+    res.status(500).json({ error: "Unable to load the ticket" });
+    return;
+  }
+
+  try {
+    // BR-13 — another requester's ticket answers exactly like a missing one.
+    const ticket = await getPrisma().ticket.findFirst({
+      where: { id: ticketId, requesterId },
+      select: {
+        ...ticketDetailSelect,
+        attachments: {
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            ticketId: true,
+            originalFilename: true,
+            mimeType: true,
+            sizeBytes: true,
+            uploadedAt: true,
+            removedAt: true,
+            removalReason: true,
+            uploadedBy: { select: { id: true, name: true } },
+            removedBy: { select: { id: true, name: true } },
+          },
+        },
+      },
+    });
+
+    if (!ticket) {
+      res.status(404).json({ error: "Ticket not found" });
+      return;
+    }
+
+    const { attachments, ...rest } = ticket;
+    res.status(200).json({ ...rest, attachments: attachments.map(serializeAttachment) });
+  } catch {
+    res.status(500).json({ error: "Unable to load the ticket" });
   }
 });

--- a/server/tests/lab-02/attachment-rules.unit.test.ts
+++ b/server/tests/lab-02/attachment-rules.unit.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import {
+  MAX_FILE_BYTES,
+  buildStoredFilename,
+  isAllowedType,
+  storedFilePath,
+  UPLOAD_DIR,
+} from "../../src/lib/attachments.js";
+import { validateRemovalReason } from "../../src/lib/validation.js";
+
+// UNIT-06, UNIT-07 — docs/lab-02/tests.md §2.1 (BR-31, BR-32, BR-35, BR-37)
+
+describe("attachment type and size rules", () => {
+  it("accepts the four permitted types", () => {
+    expect(isAllowedType("image/jpeg", "photo.jpg")).toBe(true);
+    expect(isAllowedType("image/jpeg", "photo.jpeg")).toBe(true);
+    expect(isAllowedType("image/png", "screenshot.PNG")).toBe(true);
+    expect(isAllowedType("image/webp", "capture.webp")).toBe(true);
+    expect(isAllowedType("application/pdf", "report.pdf")).toBe(true);
+  });
+
+  it("rejects a disallowed type", () => {
+    expect(isAllowedType("application/x-msdownload", "setup.exe")).toBe(false);
+    expect(isAllowedType("text/plain", "notes.txt")).toBe(false);
+  });
+
+  it("rejects a file whose extension does not match its MIME type", () => {
+    expect(isAllowedType("application/pdf", "invoice.png")).toBe(false);
+    expect(isAllowedType("image/png", "payload.exe")).toBe(false);
+  });
+
+  it("fixes the size limit at exactly 5 MB", () => {
+    expect(MAX_FILE_BYTES).toBe(5 * 1024 * 1024);
+    expect(MAX_FILE_BYTES).toBe(5_242_880);
+  });
+});
+
+describe("safe stored filenames", () => {
+  it("stores a UUID plus the validated extension, never the original name", () => {
+    const stored = buildStoredFilename("application/pdf", "battery report.pdf");
+
+    expect(stored).toMatch(/^[0-9a-f-]{36}\.pdf$/);
+    expect(stored).not.toContain("battery");
+    expect(stored).not.toContain(" ");
+  });
+
+  it("cannot be used to escape the upload directory", () => {
+    const stored = buildStoredFilename("image/png", "../../etc/passwd.png");
+
+    expect(stored).not.toContain("..");
+    expect(stored).not.toContain("/");
+
+    const resolved = path.resolve(storedFilePath("../../etc/passwd"));
+    expect(resolved.startsWith(path.resolve(UPLOAD_DIR))).toBe(true);
+  });
+
+  it("gives every upload a distinct stored name", () => {
+    const names = new Set(Array.from({ length: 20 }, () => buildStoredFilename("image/png", "same.png")));
+    expect(names.size).toBe(20);
+  });
+});
+
+describe("removal reason", () => {
+  it("requires 3 to 200 trimmed characters", () => {
+    expect(validateRemovalReason("ab").errors[0].field).toBe("reason");
+    expect(validateRemovalReason("   ").errors[0].message).toMatch(/required/i);
+    expect(validateRemovalReason("a".repeat(201)).errors[0].field).toBe("reason");
+    expect(validateRemovalReason("  wrong file  ").value).toBe("wrong file");
+  });
+});

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { readFile, rm } from "node:fs/promises";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { formatTicketNumber } from "../../src/lib/ticket-number.js";
+import { MAX_FILE_BYTES, storedFilePath } from "../../src/lib/attachments.js";
+
+// API-18 … API-28 — docs/lab-02/tests.md §2.2
+
+const prisma = getPrisma();
+const createdTicketIds: number[] = [];
+const storedFilenames: string[] = [];
+
+let ownerId = 0;
+let otherId = 0;
+let ownedTicketId = 0;
+let foreignTicketId = 0;
+
+// A one-pixel PNG is enough to prove the byte-for-byte round trip.
+const PNG_BYTES = Buffer.from(
+  "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d4944415478da63f8ffff3f0005fe02fea735a3250000000049454e44ae426082",
+  "hex"
+);
+const PDF_BYTES = Buffer.from("%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF", "utf8");
+
+async function makeTicket(requesterId: number, summary: string) {
+  const category = await prisma.category.findFirst({ where: { isActive: true }, orderBy: { id: "asc" } });
+  const relatedSystem = await prisma.relatedSystem.findFirst({
+    where: { isActive: true },
+    orderBy: { id: "asc" },
+  });
+
+  const draft = await prisma.ticket.create({
+    data: {
+      ticketNumber: `PENDING-att-${Date.now()}-${Math.random()}`,
+      requesterId,
+      categoryId: category!.id,
+      relatedSystemId: relatedSystem!.id,
+      summary,
+      description: "Seeded by the attachments API test suite to verify the attachment lifecycle.",
+      requestedPriority: "LOW",
+    },
+    select: { id: true, createdAt: true },
+  });
+
+  const ticket = await prisma.ticket.update({
+    where: { id: draft.id },
+    data: { ticketNumber: formatTicketNumber(draft.createdAt.getFullYear(), draft.id) },
+    select: { id: true },
+  });
+
+  createdTicketIds.push(ticket.id);
+  return ticket.id;
+}
+
+function uploadTo(ticketId: number, requesterId: number, filename: string, bytes: Buffer, contentType: string) {
+  return request(app)
+    .post(`/api/tickets/${ticketId}/attachments`)
+    .set("X-Requester-Id", String(requesterId))
+    .attach("file", bytes, { filename, contentType });
+}
+
+async function trackStoredFilename(attachmentId: number) {
+  const row = await prisma.attachment.findUnique({
+    where: { id: attachmentId },
+    select: { storedFilename: true },
+  });
+  if (row) storedFilenames.push(row.storedFilename);
+  return row?.storedFilename ?? "";
+}
+
+beforeAll(async () => {
+  const requesters = await prisma.requesterUser.findMany({
+    where: { isActive: true },
+    orderBy: { id: "asc" },
+    take: 2,
+  });
+  ownerId = requesters[0].id;
+  otherId = requesters[1].id;
+
+  ownedTicketId = await makeTicket(ownerId, "Attachment test — owned ticket");
+  foreignTicketId = await makeTicket(otherId, "Attachment test — other requester's ticket");
+});
+
+afterAll(async () => {
+  await prisma.attachment.deleteMany({ where: { ticketId: { in: createdTicketIds } } });
+  await prisma.ticket.deleteMany({ where: { id: { in: createdTicketIds } } });
+  for (const stored of storedFilenames) {
+    await rm(storedFilePath(stored), { force: true });
+  }
+});
+
+describe("POST /api/tickets/:id/attachments", () => {
+  // API-18 / AC-27, BR-34
+  it("stores a permitted file with its metadata and returns 201", async () => {
+    const res = await uploadTo(ownedTicketId, ownerId, "battery-report.pdf", PDF_BYTES, "application/pdf");
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      ticketId: ownedTicketId,
+      originalFilename: "battery-report.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: PDF_BYTES.length,
+      state: "ACTIVE",
+    });
+    expect(res.body.uploadedBy.id).toBe(ownerId);
+    expect(res.body.uploadedAt).toBeTruthy();
+
+    const stored = await trackStoredFilename(res.body.id);
+    expect(stored).toMatch(/^[0-9a-f-]{36}\.pdf$/);
+    await expect(readFile(storedFilePath(stored))).resolves.toBeTruthy();
+  });
+
+  // API-19 / AC-14, BR-31
+  it("rejects an unsupported type with 415 and stores nothing", async () => {
+    const before = await prisma.attachment.count({ where: { ticketId: ownedTicketId } });
+
+    const res = await uploadTo(
+      ownedTicketId,
+      ownerId,
+      "setup.exe",
+      Buffer.from("MZ binary"),
+      "application/x-msdownload"
+    );
+
+    expect(res.status).toBe(415);
+    expect(res.body.error).toMatch(/JPG, PNG, WEBP and PDF/);
+    expect(await prisma.attachment.count({ where: { ticketId: ownedTicketId } })).toBe(before);
+  });
+
+  it("rejects a file whose extension does not match its MIME type", async () => {
+    const res = await uploadTo(ownedTicketId, ownerId, "payload.exe", PNG_BYTES, "image/png");
+
+    expect(res.status).toBe(415);
+  });
+
+  // API-20 / AC-14, BR-32
+  it("rejects a file larger than 5 MB with 413", async () => {
+    const tooBig = Buffer.alloc(MAX_FILE_BYTES + 1, 0);
+    const res = await uploadTo(ownedTicketId, ownerId, "huge.png", tooBig, "image/png");
+
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/5 MB or smaller/);
+  });
+
+  // API-21 / AC-28, BR-33
+  it("refuses a sixth active attachment with 409", async () => {
+    const ticketId = await makeTicket(ownerId, "Attachment test — limit ticket");
+
+    for (let i = 0; i < 5; i++) {
+      const res = await uploadTo(ticketId, ownerId, `evidence-${i}.png`, PNG_BYTES, "image/png");
+      expect(res.status).toBe(201);
+      await trackStoredFilename(res.body.id);
+    }
+
+    const sixth = await uploadTo(ticketId, ownerId, "evidence-5.png", PNG_BYTES, "image/png");
+    expect(sixth.status).toBe(409);
+    expect(sixth.body.error).toMatch(/at most 5 active attachments/);
+    expect(await prisma.attachment.count({ where: { ticketId, removedAt: null } })).toBe(5);
+  });
+
+  // API-28 / BR-33 — a removed attachment frees its slot
+  it("accepts a new upload after one of five is removed", async () => {
+    const ticketId = await makeTicket(ownerId, "Attachment test — slot ticket");
+
+    const uploaded = [];
+    for (let i = 0; i < 5; i++) {
+      const res = await uploadTo(ticketId, ownerId, `slot-${i}.png`, PNG_BYTES, "image/png");
+      uploaded.push(res.body.id);
+      await trackStoredFilename(res.body.id);
+    }
+
+    await request(app)
+      .patch(`/api/attachments/${uploaded[0]}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ reason: "Uploaded the wrong screenshot" })
+      .expect(200);
+
+    const replacement = await uploadTo(ticketId, ownerId, "slot-replacement.png", PNG_BYTES, "image/png");
+    expect(replacement.status).toBe(201);
+    await trackStoredFilename(replacement.body.id);
+  });
+
+  it("answers 404 when the ticket belongs to another requester", async () => {
+    const res = await uploadTo(foreignTicketId, ownerId, "sneaky.png", PNG_BYTES, "image/png");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Ticket not found" });
+  });
+});
+
+describe("attachment metadata, download, and soft removal", () => {
+  let attachmentId = 0;
+  let listTicketId = 0;
+
+  beforeAll(async () => {
+    listTicketId = await makeTicket(ownerId, "Attachment test — lifecycle ticket");
+    const res = await uploadTo(listTicketId, ownerId, "screenshot.png", PNG_BYTES, "image/png");
+    attachmentId = res.body.id;
+    await trackStoredFilename(attachmentId);
+  });
+
+  // API-22 / AC-29
+  it("downloads an active attachment with its original filename", async () => {
+    const res = await request(app)
+      .get(`/api/attachments/${attachmentId}/download`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("image/png");
+    expect(res.headers["content-disposition"]).toContain('filename="screenshot.png"');
+    expect(Buffer.from(res.body)).toEqual(PNG_BYTES);
+  });
+
+  // API-27 / AC-33, BR-38
+  it("answers 404 when another requester tries to download it", async () => {
+    const res = await request(app)
+      .get(`/api/attachments/${attachmentId}/download`)
+      .set("X-Requester-Id", String(otherId));
+
+    expect(res.status).toBe(404);
+  });
+
+  // API-26 / AC-34, BR-37
+  it("rejects removal without a usable reason and keeps the attachment active", async () => {
+    const res = await request(app)
+      .patch(`/api/attachments/${attachmentId}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ reason: "ab" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.fields[0].field).toBe("reason");
+
+    const row = await prisma.attachment.findUnique({ where: { id: attachmentId } });
+    expect(row!.removedAt).toBeNull();
+  });
+
+  // API-27 / AC-33 — removal is owner-only
+  it("answers 404 when another requester tries to remove it", async () => {
+    const res = await request(app)
+      .patch(`/api/attachments/${attachmentId}/remove`)
+      .set("X-Requester-Id", String(otherId))
+      .send({ reason: "Not mine to remove" });
+
+    expect(res.status).toBe(404);
+    const row = await prisma.attachment.findUnique({ where: { id: attachmentId } });
+    expect(row!.removedAt).toBeNull();
+  });
+
+  // API-23 / AC-30, BR-36
+  it("soft-removes the attachment, keeping the row and its metadata", async () => {
+    const res = await request(app)
+      .patch(`/api/attachments/${attachmentId}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ reason: "  Uploaded the wrong screenshot  " });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      id: attachmentId,
+      state: "REMOVED",
+      removalReason: "Uploaded the wrong screenshot",
+    });
+    expect(res.body.removedBy.id).toBe(ownerId);
+
+    const row = await prisma.attachment.findUnique({ where: { id: attachmentId } });
+    expect(row).not.toBeNull();
+    expect(row!.removedAt).not.toBeNull();
+    expect(row!.originalFilename).toBe("screenshot.png");
+  });
+
+  // API-23 / BR-39 — the metadata stays visible in the list
+  it("still lists the removed attachment with its reason", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${listTicketId}/attachments`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(res.status).toBe(200);
+    const removed = res.body.find((a: { id: number }) => a.id === attachmentId);
+    expect(removed).toMatchObject({
+      state: "REMOVED",
+      originalFilename: "screenshot.png",
+      removalReason: "Uploaded the wrong screenshot",
+    });
+  });
+
+  // API-24 / AC-31, BR-39
+  it("answers 410 and serves no content when a removed attachment is downloaded", async () => {
+    const res = await request(app)
+      .get(`/api/attachments/${attachmentId}/download`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(res.status).toBe(410);
+    expect(res.body).toEqual({ error: "This attachment has been removed" });
+  });
+
+  // API-25 / AC-32, BR-40
+  it("answers 409 when the same attachment is removed twice", async () => {
+    const res = await request(app)
+      .patch(`/api/attachments/${attachmentId}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ reason: "Trying again" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already been removed/);
+  });
+
+  it("returns the ticket detail with both active and removed attachments", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${listTicketId}`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(res.status).toBe(200);
+    expect(res.body.attachments.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.attachments.some((a: { state: string }) => a.state === "REMOVED")).toBe(true);
+  });
+});

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -56,24 +56,32 @@ function list(query: string, requesterId: number | null = ownerId) {
   return req;
 }
 
-beforeAll(async () => {
-  const requesters = await prisma.requesterUser.findMany({
-    where: { isActive: true },
-    orderBy: { id: "asc" },
-    take: 3,
+// Dedicated test requesters: the suite needs exact counts, so it must never
+// depend on — or delete — the tickets a developer created by hand.
+async function testRequester(slug: string) {
+  const email = `lab2-${slug}@tests.toktickit.local`;
+  const requester = await prisma.requesterUser.upsert({
+    where: { email },
+    update: {},
+    create: { name: `Lab 2 test ${slug}`, email, department: "Automated tests", isActive: true },
+    select: { id: true },
   });
+  return requester.id;
+}
+
+beforeAll(async () => {
   const categories = await prisma.category.findMany({ where: { isActive: true }, orderBy: { id: "asc" }, take: 2 });
   const relatedSystem = await prisma.relatedSystem.findFirst({ where: { isActive: true }, orderBy: { id: "asc" } });
 
-  ownerId = requesters[0].id;
-  otherId = requesters[1].id;
-  emptyRequesterId = requesters[2].id;
+  ownerId = await testRequester("list-owner");
+  otherId = await testRequester("list-other");
+  emptyRequesterId = await testRequester("list-empty");
   categoryA = categories[0].id;
   categoryB = categories[1].id;
   relatedSystemId = relatedSystem!.id;
 
-  // The owner keeps a clean slate so counts in this suite are exact.
-  await prisma.ticket.deleteMany({ where: { requesterId: { in: [ownerId, emptyRequesterId] } } });
+  // Only this suite's own leftovers are cleared.
+  await prisma.ticket.deleteMany({ where: { requesterId: { in: [ownerId, otherId, emptyRequesterId] } } });
 
   const base = new Date("2026-03-01T00:00:00.000Z");
   for (let i = 0; i < 12; i++) {
@@ -91,7 +99,10 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await prisma.ticket.deleteMany({ where: { id: { in: createdIds } } });
+  // Leave the database exactly as the suite found it: no test tickets and no
+  // test requesters lingering in the Development Requester selector.
+  await prisma.ticket.deleteMany({ where: { requesterId: { in: [ownerId, otherId, emptyRequesterId] } } });
+  await prisma.requesterUser.deleteMany({ where: { id: { in: [ownerId, otherId, emptyRequesterId] } } });
 });
 
 describe("GET /api/tickets", () => {

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { formatTicketNumber } from "../../src/lib/ticket-number.js";
+
+// API-15, API-16, API-17 — docs/lab-02/tests.md §2.2
+
+const prisma = getPrisma();
+const createdIds: number[] = [];
+
+let ownerId = 0;
+let otherId = 0;
+let ownedTicketId = 0;
+let foreignTicketId = 0;
+
+async function makeTicket(requesterId: number, summary: string) {
+  const category = await prisma.category.findFirst({ where: { isActive: true }, orderBy: { id: "asc" } });
+  const relatedSystem = await prisma.relatedSystem.findFirst({
+    where: { isActive: true },
+    orderBy: { id: "asc" },
+  });
+
+  const draft = await prisma.ticket.create({
+    data: {
+      ticketNumber: `PENDING-detail-${Date.now()}-${Math.random()}`,
+      requesterId,
+      categoryId: category!.id,
+      relatedSystemId: relatedSystem!.id,
+      summary,
+      description: "Seeded by the ticket-detail API test suite to verify ownership behaviour.",
+      requestedPriority: "MEDIUM",
+    },
+    select: { id: true, createdAt: true },
+  });
+
+  const ticket = await prisma.ticket.update({
+    where: { id: draft.id },
+    data: { ticketNumber: formatTicketNumber(draft.createdAt.getFullYear(), draft.id) },
+    select: { id: true },
+  });
+
+  createdIds.push(ticket.id);
+  return ticket.id;
+}
+
+beforeAll(async () => {
+  const requesters = await prisma.requesterUser.findMany({
+    where: { isActive: true },
+    orderBy: { id: "asc" },
+    take: 2,
+  });
+  ownerId = requesters[0].id;
+  otherId = requesters[1].id;
+
+  ownedTicketId = await makeTicket(ownerId, "Detail test — owned ticket");
+  foreignTicketId = await makeTicket(otherId, "Detail test — another requester's ticket");
+});
+
+afterAll(async () => {
+  await prisma.ticket.deleteMany({ where: { id: { in: createdIds } } });
+});
+
+describe("GET /api/tickets/:id", () => {
+  // API-15 / AC-25
+  it("returns the full ticket for its owner", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${ownedTicketId}`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(ownedTicketId);
+    expect(res.body.summary).toBe("Detail test — owned ticket");
+    expect(res.body.status).toBe("NEW");
+    expect(res.body.requester.id).toBe(ownerId);
+    expect(res.body.category).toHaveProperty("name");
+    expect(res.body.relatedSystem).toHaveProperty("name");
+    expect(res.body.attachments).toEqual([]);
+  });
+
+  // API-16 / AC-26, BR-13
+  it("answers 404 for a ticket that belongs to another requester and leaks nothing", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${foreignTicketId}`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Ticket not found" });
+  });
+
+  it("answers 404 the same way for a ticket that does not exist", async () => {
+    const missing = await request(app).get("/api/tickets/99999999").set("X-Requester-Id", String(ownerId));
+    const foreign = await request(app)
+      .get(`/api/tickets/${foreignTicketId}`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(missing.status).toBe(foreign.status);
+    expect(missing.body).toEqual(foreign.body);
+  });
+
+  // API-17 / api-spec §3.3
+  it("rejects a non-integer id with 400", async () => {
+    const res = await request(app).get("/api/tickets/abc").set("X-Requester-Id", String(ownerId));
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid ticket id" });
+  });
+
+  it("requires a Development Requester header", async () => {
+    const res = await request(app).get(`/api/tickets/${ownedTicketId}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.field).toBe("X-Requester-Id");
+  });
+});


### PR DESCRIPTION
Implements api-spec.md §3.3 and §4, and ui-spec.md §7.4/§7.5.

**Backend**
- `GET /api/tickets/:id` returns the ticket with its attachments only to its owner; a foreign ticket answers exactly like a missing one — same status, same body (BR-13), which the test asserts by comparing the two responses.
- `POST /api/tickets/:id/attachments` (multer, memory storage) enforces type by extension **and** MIME (415), 5 MB (413), and the five-active limit (409). The file is written only after every rule passes, and a failed database write deletes the orphan so storage and metadata cannot diverge (BR-42).
- `GET /api/attachments/:id/download` streams the bytes with the original filename; a soft-removed attachment answers 410, not 404, because the record legitimately exists (BR-39).
- `PATCH /api/attachments/:id/remove` is soft removal only — sets `removedAt`, `removalReason`, `removedByRequesterId` and keeps the row (BR-36). Reason is required, 3–200 characters (BR-37); removing twice is 409.
- Stored filenames are UUID + validated extension, so the original name is never a path (BR-35); a unit test proves `../../etc/passwd` cannot escape the upload directory.

**Frontend**
- Ticket Detail is fully read-only: the test asserts that zero non-readonly textboxes and no select exist on the page (AC-25).
- Attachment section with the active count, per-attachment state badge, Download and Remove, the removal dialog with its required reason, and disabled Add with an explanation at five active files.
- A removed attachment stays listed with its reason and date, and both of its actions are disabled (BR-39).
- Downloads go through `fetch` so the identity header is sent, then hand the blob to the browser — a plain `<a href>` could not carry the header.
- Create Ticket now has its attachment picker: invalid files are rejected by name while valid ones stay selected, and uploads run after the ticket is saved. An upload failure never rolls back the ticket; it is reported per file (BR-41).

**Test-hygiene fix:** the My Tickets API suite used to delete the first seeded requester's tickets to get exact counts, which wiped hand-created demo data. It now creates its own throwaway requesters and removes them afterwards.

## Verification
- Server 73/73 pass — UNIT-06, UNIT-07, API-15…API-28.
- Client 57/57 pass — UI-09, UI-15…UI-20.
- `tsc --noEmit` clean on both sides.
- Manual through the browser on ticket 147: uploaded `evidence.pdf` → listed Active, "1 of 5"; removed it with a reason → shows Removed with the reason and date, count back to "0 of 5", both buttons disabled. Direct API checks: owner downloading the removed file gets 410, requester 2 gets 404 for both the ticket and the attachment.

Closes #18