### PR TITLE
docs(lab-02): record the review comments and replies for PR #28, #29 and #30

### DIFF
--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -70,6 +70,23 @@ metadata survives, the content does not.
 My response: "Pass omg thanks" — reviewed and merged after the two layout defects found by the
 responsive run were fixed in the same PR.
 
+**PR #28 — Final documentation**
+> **@asamapornch:** docs done and test result match. approve
+
+My response: "Finally thank you" — the reviewer checked the numbers in `tests.md` against the actual
+test output rather than taking the summary on trust.
+
+**PR #29 — Documentation set completed**
+> **@asamapornch:** nice, ready to merge
+
+My response: "finally the last ig thanks" — last documentation pass before the release Pull Request.
+
+**PR #30 — Lab 2 release into `main`**
+> **@asamapornch:** everything merged. test green. approve
+
+My response: "Thank you" — the release Pull Request was reviewed on a clean `lab2-staging`, and the
+full suite was run again on `main` after the merge.
+
 ---
 
 ## 2. Pull Requests I reviewed for my partner


### PR DESCRIPTION
## What

`docs/lab-02/reviewer.md` narrated the review comment and my reply for PR #21 through #27 only. PR #28, #29 and #30 appeared in the summary table but their review conversations were missing.

This adds the three missing entries, including the release Pull Request.

## Why

Lab 2 section 14 Part 1 asks for the comments received and the responses given, so every reviewed Pull Request needs its conversation recorded, not just its verdict.

## Changes

- `docs/lab-02/reviewer.md`: three entries added under "Comments I received, and how I responded"

## Verification

Documentation only. No code, schema or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)